### PR TITLE
Switch to docker image for Codeowners Plus

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - name: 'Build & Publish'
         uses: elgohr/Publish-Docker-Github-Action@eb53b3ec07136a6ebaed78d8135806da64f7c7e2  # v5
         with:
-          name: multimediallc/mm-codeowners
+          name: multimediallc/codeowners-plus
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           registry: ghcr.io

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,4 @@ inputs:
 
 runs:
   using: 'docker'
-  # image: 'docker://ghcr.io/multimediallc/mm-codeowners:v0.1.0'  # uncomment for v0.1 release
-  image: 'Dockerfile'
+  image: 'docker://ghcr.io/multimediallc/codeowners-plus:v0.1.0'

--- a/action.yml
+++ b/action.yml
@@ -19,4 +19,4 @@ inputs:
 
 runs:
   using: 'docker'
-  image: 'docker://ghcr.io/multimediallc/codeowners-plus:v0.1.0'
+  image: 'docker://ghcr.io/multimediallc/codeowners-plus:latest'

--- a/pkg/codeowners/codeowners_test.go
+++ b/pkg/codeowners/codeowners_test.go
@@ -119,7 +119,7 @@ func TestGetOwnersFail(t *testing.T) {
 	rgMan := NewReviewerGroupMemo()
 	tree := initOwnerTreeNode("../../test_project", "../../test_project", rgMan, nil, io.Discard)
 	testMap := tree.BuildFromFiles(files, rgMan)
-	files = append(files, "non_existant_file")
+	files = append(files, "non_existent_file")
 	_, err := testMap.getOwners(files)
 	if err == nil {
 		t.Errorf("Expected error getting owners: %v", err)


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

This PR switches from Dockerfile to use the image from ghcr.io available as of v0.1.0