### PR TITLE
feat: Implement high priority indicator via PR labels

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -1,2 +1,3 @@
 # For now, Hans reviews everything
 * @BakerNet
+codeowners.toml @zbedforrest

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -7,7 +7,7 @@ concurrency:
 on:
   pull_request:
     branches: [main]
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
 jobs:
   codeowners:

--- a/README.md
+++ b/README.md
@@ -254,10 +254,11 @@ high_priority_labels = ["high-priority", "urgent"]
 
 When a PR has any of these labels, the comment will look like this:
 ```
+❗High Prio❗ 
+
 Codeowners approval required for this PR:
 - @user1
 - @user2
-❗High Prio❗
 ```
 
 ## CLI Tool

--- a/README.md
+++ b/README.md
@@ -257,7 +257,6 @@ When a PR has any of these labels, the comment will look like this:
 Codeowners approval required for this PR:
 - @user1
 - @user2
-
 ❗High Prio❗
 ```
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ concurrency:
 
 on:
   pull_request:
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
 jobs:
   codeowners:

--- a/README.md
+++ b/README.md
@@ -244,6 +244,23 @@ To prevent ownership rules from being checked or applied for certain directories
 ignore = ["test_project"]
 ```
 
+### High Priority Labels
+
+You can configure labels that indicate a high priority PR. When a PR has any of these labels, the comment will include a high priority indicator:
+
+```toml
+high_priority_labels = ["high-priority", "urgent"]
+```
+
+When a PR has any of these labels, the comment will look like this:
+```
+Codeowners approval required for this PR:
+- @user1
+- @user2
+
+❗High Prio❗
+```
+
 ## CLI Tool
 
 A CLI tool is available which provides some utilities for working with `.codeowners` files.

--- a/codeowners.toml
+++ b/codeowners.toml
@@ -7,7 +7,7 @@ unskippable_reviewers = ["@BakerNet"]
 # `ignore` allows you to specify directories that should be ignored by the codeowners check
 ignore = ["test_project"]
 # `high_priority_lables` allows you to specify labels that should be considered high priority
-high_priority_lables = ["P0"]
+high_priority_labels = ["P0"]
 
 # `enforcement` allows you to specify how the codeowners check should be enforced
 [enforcement]

--- a/codeowners.toml
+++ b/codeowners.toml
@@ -6,6 +6,8 @@ max_reviews = 2
 unskippable_reviewers = ["@BakerNet"]
 # `ignore` allows you to specify directories that should be ignored by the codeowners check
 ignore = ["test_project"]
+# `high_priority_lables` allows you to specify labels that should be considered high priority
+high_priority_lables = ["P0"]
 
 # `enforcement` allows you to specify how the codeowners check should be enforced
 [enforcement]

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -14,6 +14,7 @@ type Config struct {
 	UnskippableReviewers []string     `toml:"unskippable_reviewers"`
 	Ignore               []string     `toml:"ignore"`
 	Enforcement          *Enforcement `toml:"enforcement"`
+	HighPriorityLabels   []string     `toml:"high_priority_labels"`
 }
 
 type Enforcement struct {
@@ -32,6 +33,7 @@ func ReadConfig(path string) (*Config, error) {
 		UnskippableReviewers: []string{},
 		Ignore:               []string{},
 		Enforcement:          &Enforcement{Approval: false, FailCheck: true},
+		HighPriorityLabels:   []string{},
 	}
 
 	fileName := path + "codeowners.toml"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -36,6 +36,7 @@ ignore = ["ignored/"]
 [enforcement]
 approval = true
 fail_check = false
+high_priority_labels = ["high-priority", "urgent"]
 `,
 			path: "testdata/",
 			expected: &Config{
@@ -44,6 +45,7 @@ fail_check = false
 				UnskippableReviewers: []string{"@user1", "@user2"},
 				Ignore:               []string{"ignored/"},
 				Enforcement:          &Enforcement{Approval: true, FailCheck: false},
+				HighPriorityLabels:   []string{"high-priority", "urgent"},
 			},
 			expectedErr: false,
 		},
@@ -60,6 +62,7 @@ unskippable_reviewers = ["@user1"]
 				UnskippableReviewers: []string{"@user1"},
 				Ignore:               []string{},
 				Enforcement:          &Enforcement{Approval: false, FailCheck: true},
+				HighPriorityLabels:   []string{},
 			},
 			expectedErr: false,
 		},

--- a/internal/github/approvals.go
+++ b/internal/github/approvals.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/multimediallc/codeowners-plus/internal/git"
 	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
-	"github.com/multimediallc/codeowners-plus/pkg/functional"
+	f "github.com/multimediallc/codeowners-plus/pkg/functional"
 )
 
 type approvalWithDiff struct {

--- a/main.go
+++ b/main.go
@@ -218,7 +218,7 @@ func (a *App) processApprovalsAndReviewers() (bool, string, error) {
 		if err != nil {
 			fmt.Fprintf(WarningBuffer, "WARNING: Error checking high priority labels: %v\n", err)
 		} else if hasHighPriority {
-			comment += "\n❗High Prio❗"
+			comment = "❗High Prio❗\n\n" + comment
 		}
 		if maxReviewsMet {
 			comment += "\n\n"

--- a/main.go
+++ b/main.go
@@ -11,11 +11,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/multimediallc/codeowners-plus/internal/config"
+	owners "github.com/multimediallc/codeowners-plus/internal/config"
 	"github.com/multimediallc/codeowners-plus/internal/git"
-	"github.com/multimediallc/codeowners-plus/internal/github"
+	gh "github.com/multimediallc/codeowners-plus/internal/github"
 	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
-	"github.com/multimediallc/codeowners-plus/pkg/functional"
+	f "github.com/multimediallc/codeowners-plus/pkg/functional"
 )
 
 // AppConfig holds the application configuration
@@ -214,6 +214,12 @@ func (a *App) processApprovalsAndReviewers() (bool, string, error) {
 	if len(unapprovedOwners) > 0 {
 		// Comment on the PR with the codeowner teams that have not approved the PR
 		comment := allRequiredOwners.ToCommentString()
+		hasHighPriority, err := a.client.IsInLabels(a.conf.HighPriorityLabels)
+		if err != nil {
+			fmt.Fprintf(WarningBuffer, "WARNING: Error checking high priority labels: %v\n", err)
+		} else if hasHighPriority {
+			comment += "\n❗High Prio❗"
+		}
 		if maxReviewsMet {
 			comment += "\n\n"
 			comment += "The PR has received the max number of required reviews.  No further action is required."

--- a/main_test.go
+++ b/main_test.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/google/go-github/v63/github"
-	"github.com/multimediallc/codeowners-plus/internal/config"
+	owners "github.com/multimediallc/codeowners-plus/internal/config"
 	"github.com/multimediallc/codeowners-plus/internal/git"
-	"github.com/multimediallc/codeowners-plus/internal/github"
+	gh "github.com/multimediallc/codeowners-plus/internal/github"
 	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
 	f "github.com/multimediallc/codeowners-plus/pkg/functional"
 )
@@ -257,6 +257,23 @@ func (m *mockGitHubClient) IsSubstringInComments(substring string, since *time.T
 		}
 		if strings.Contains(c.GetBody(), substring) {
 			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func (m *mockGitHubClient) IsInLabels(labels []string) (bool, error) {
+	if m.pr == nil {
+		return false, &gh.NoPRError{}
+	}
+	if len(labels) == 0 {
+		return false, nil
+	}
+	for _, label := range m.pr.Labels {
+		for _, targetLabel := range labels {
+			if label.GetName() == targetLabel {
+				return true, nil
+			}
 		}
 	}
 	return false, nil

--- a/pkg/codeowners/codeowners_test.go
+++ b/pkg/codeowners/codeowners_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/multimediallc/codeowners-plus/pkg/functional"
+	f "github.com/multimediallc/codeowners-plus/pkg/functional"
 )
 
 func TestInitOwnerTree(t *testing.T) {

--- a/pkg/codeowners/reviewers.go
+++ b/pkg/codeowners/reviewers.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
-	"github.com/multimediallc/codeowners-plus/pkg/functional"
+	f "github.com/multimediallc/codeowners-plus/pkg/functional"
 )
 
 var commentPrefix = "Codeowners approval required for this PR:\n"

--- a/pkg/codeowners/reviewers_test.go
+++ b/pkg/codeowners/reviewers_test.go
@@ -5,7 +5,7 @@ import (
 	"sort"
 	"testing"
 
-	"github.com/multimediallc/codeowners-plus/pkg/functional"
+	f "github.com/multimediallc/codeowners-plus/pkg/functional"
 )
 
 func TestToReviewers(t *testing.T) {

--- a/tools/cli/main.go
+++ b/tools/cli/main.go
@@ -11,7 +11,7 @@ import (
 
 	"github.com/boyter/gocodewalker"
 	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
-	"github.com/multimediallc/codeowners-plus/pkg/functional"
+	f "github.com/multimediallc/codeowners-plus/pkg/functional"
 	"github.com/urfave/cli/v2"
 )
 


### PR DESCRIPTION
## Related Issue(s)

<!--
Delete this section if there is no Issue this PR attempts to resolve or make progress on.
-->

- #15 

## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

Received a feature request to add a high priority indicator to review request comments so these PRs can move forward more quickly.

This PR adds a way to mark labels as high priority in the `codeowners.toml` config