### PR TITLE
fix: Comments after an Approval break approval

### DIFF
--- a/.codeowners
+++ b/.codeowners
@@ -1,3 +1,2 @@
 # For now, Hans reviews everything
-* @BakerNet
-codeowners.toml @zbedforrest
+* @BakerNet @zbedforrest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-83.0%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-83.1%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/internal/github/gh.go
+++ b/internal/github/gh.go
@@ -162,7 +162,7 @@ func (gh *GHClient) approvals() []*github.PullRequestReview {
 		if _, ok := seen[userName]; ok {
 			// we only care about the most recent reviews for each user
 			return false
-		} else {
+		} else if approval.GetState() == "APPROVED" {
 			seen[userName] = true
 		}
 		return approval.GetState() == "APPROVED"


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

A bug was reported where an approval was not being counted.  The approval filtering currently only counts the last review, not the last approval - because issue comments count as reviews, this was resulting in a comment after an approval causing the approval to not be counted.