### PR TITLE
Add flag to enable quiet mode (run without PR comments)

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -24,10 +24,11 @@ jobs:
         run: |
           sed -i "s/image: .*/image: 'Dockerfile'/" action.yml
           cat action.yml
-      
+
       - name: 'Codeowners Plus'
         uses: ./
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           pr: '${{ github.event.pull_request.number }}'
           verbose: true
+          quiet: false

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -13,7 +13,6 @@ jobs:
   codeowners:
     name: 'Run Codeowners Plus'
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }}
     steps:
       - name: 'Checkout Code Repository'
         uses: actions/checkout@v4
@@ -31,4 +30,4 @@ jobs:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           pr: '${{ github.event.pull_request.number }}'
           verbose: true
-          quiet: false
+          quiet: ${{ github.event.pull_request.draft }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,7 +18,7 @@ Thank you for considering contributing to Codeowners Plus! We welcome contributi
 > Running locally still requires real Github PRs to exist that you are testing against.
 
 ```bash
-go run main.go -token <your_gh_token> -dir ../chaturbate -pr <pr_num> -repo multimediallc/chaturbate -v true
+go run main.go -token <your_gh_token> -dir ../chaturbate -pr <pr_num> -repo multimediallc/chaturbate -v true -quiet=true
 ```
 
 #### Running the CLI tool Locally

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Codeowners Plus'
-        uses: multimediallc/codeowners-plus@v0.1.0
+        uses: multimediallc/codeowners-plus@v0.1.2
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           pr: '${{ github.event.pull_request.number }}'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-83.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.7%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      
+
       - name: 'Codeowners Plus'
         uses: multimediallc/codeowners-plus@v0.1.0
         with:
@@ -121,7 +121,7 @@ By default, each file will resolve to a single reviewer.  See [priority section]
 
 To instead require an owner as an additional reviewer (`AND` rule), put an `&` at the start of the line:
 ```
-# this rule will add `@task-auditor` as a required review in addition to the file owner's required review  
+# this rule will add `@task-auditor` as a required review in addition to the file owner's required review
 & **/task.go @task-auditor
 ```
 
@@ -219,7 +219,7 @@ If you want to allow PR authors to bypass some reviews when there are a large nu
 
 `codeowners.toml`
 ```toml
-# 
+#
 # `max_reviews` (default nil) allows you to skip some reviewers if the number of reviewers is greater than the max_reviewers
 max_reviews = 2
 ```
@@ -254,12 +254,44 @@ high_priority_labels = ["high-priority", "urgent"]
 
 When a PR has any of these labels, the comment will look like this:
 ```
-❗High Prio❗ 
+❗High Prio❗
 
 Codeowners approval required for this PR:
 - @user1
 - @user2
 ```
+
+### Quiet Mode
+
+You can run Codeowners Plus in a "quiet" mode using the `quiet` input in the GitHub Action or the `-quiet=true` flag in the CLI.
+
+**When Quiet Mode is Enabled:**
+
+* **No Comments:** The action will **not** post the review status comment (listing required/unapproved reviewers) or the optional reviewer "cc" comment to the Pull Request.
+* **No Review Requests:** The action will **not** automatically request reviews from required owners who have not yet approved via the GitHub API.
+
+**Behavior:**
+
+Even in quiet mode, the tool still performs all its internal calculations: determining required/optional owners based on file changes, checking existing approvals, and determining if the ownership rules are satisfied. The primary outcome is still the success or failure status of the associated status check (unless you've configured `enforcement.fail_check = false`).
+
+**Use Cases:**
+
+* **Draft Pull Requests:** This is a common use case. You might want the Codeowners Plus logic to run and report a status (e.g., pending or failed) on draft PRs, but without notifying reviewers prematurely by adding comments or requesting reviews until the PR is marked "Ready for review".
+* **Custom Notification Workflows:** You might prefer to handle notifications or review requests through a different mechanism and only use Codeowners Plus for the status check enforcement.
+
+**Activation:**
+
+* **GitHub Action:** Set the `quiet` input to `'true'`.
+    ```yaml
+    - name: 'Codeowners Plus (Quiet)'
+      uses: multimediallc/codeowners-plus@v0.1.0 # Or your desired version
+      with:
+        # ... other inputs ...
+        quiet: 'true'
+    ```
+* **CLI:** Use the flag `-quiet=true`.
+
+**Default:** Quiet mode is **disabled** (`false`) by default.
 
 ## CLI Tool
 
@@ -279,4 +311,3 @@ Available commands are:
 ## Future Features
 
 * Inline ownership comments for having owners for specific functions, classes, etc.
-

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ jobs:
           fetch-depth: 0
 
       - name: 'Codeowners Plus'
-        uses: multimediallc/codeowners-plus@v0.1.2
+        uses: multimediallc/codeowners-plus@v0.1.4
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           pr: '${{ github.event.pull_request.number }}'

--- a/README.md
+++ b/README.md
@@ -284,7 +284,7 @@ Even in quiet mode, the tool still performs all its internal calculations: deter
 * **GitHub Action:** Set the `quiet` input to `'true'`.
     ```yaml
     - name: 'Codeowners Plus (Quiet)'
-      uses: multimediallc/codeowners-plus@v0.1.0 # Or your desired version
+      uses: multimediallc/codeowners-plus@v0.1.0
       with:
         # ... other inputs ...
         quiet: 'true'

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-82.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-83.3%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ Available commands are:
 * `owner` to check who owns a specific file
 * `verify` to check for typos in a `.codeowners` file
 
+## Contributing
+
+See [CONTRIBUTING.md](https://github.com/multimediallc/codeowners-plus/blob/main/CONTRIBUTING.md)
+
 ## Future Features
 
 * Inline ownership comments for having owners for specific functions, classes, etc.

--- a/README.md
+++ b/README.md
@@ -261,25 +261,25 @@ Codeowners approval required for this PR:
 - @user2
 ```
 
-### Quiet Mode
+## Quiet Mode
 
-You can run Codeowners Plus in a "quiet" mode using the `quiet` input in the GitHub Action or the `-quiet=true` flag in the CLI.
+You can run Codeowners Plus in a "quiet" mode using the `quiet` input in the GitHub Action.
 
-**When Quiet Mode is Enabled:**
+### When Quiet Mode is Enabled
 
 * **No Comments:** The action will **not** post the review status comment (listing required/unapproved reviewers) or the optional reviewer "cc" comment to the Pull Request.
 * **No Review Requests:** The action will **not** automatically request reviews from required owners who have not yet approved via the GitHub API.
 
-**Behavior:**
+### Behavior:
 
 Even in quiet mode, the tool still performs all its internal calculations: determining required/optional owners based on file changes, checking existing approvals, and determining if the ownership rules are satisfied. The primary outcome is still the success or failure status of the associated status check (unless you've configured `enforcement.fail_check = false`).
 
-**Use Cases:**
+### Use Cases:
 
 * **Draft Pull Requests:** This is a common use case. You might want the Codeowners Plus logic to run and report a status (e.g., pending or failed) on draft PRs, but without notifying reviewers prematurely by adding comments or requesting reviews until the PR is marked "Ready for review".
 * **Custom Notification Workflows:** You might prefer to handle notifications or review requests through a different mechanism and only use Codeowners Plus for the status check enforcement.
 
-**Activation:**
+### Activation:
 
 * **GitHub Action:** Set the `quiet` input to `'true'`.
     ```yaml
@@ -289,7 +289,6 @@ Even in quiet mode, the tool still performs all its internal calculations: deter
         # ... other inputs ...
         quiet: 'true'
     ```
-* **CLI:** Use the flag `-quiet=true`.
 
 **Default:** Quiet mode is **disabled** (`false`) by default.
 

--- a/main.go
+++ b/main.go
@@ -372,6 +372,11 @@ func (a *App) processApprovals(ghApprovals []*gh.CurrentApproval) (int, error) {
 }
 
 func (a *App) requestReviews() error {
+	if !a.config.AddComments {
+		printDebug("Skipping review requests (disabled in quiet mode).\n")
+		return nil
+	}
+
 	unapprovedOwners := a.codeowners.AllRequired()
 	unapprovedOwnerNames := unapprovedOwners.Flatten()
 	printDebug("Remaining Required Owners: %s\n", unapprovedOwnerNames)

--- a/main_test.go
+++ b/main_test.go
@@ -1039,10 +1039,6 @@ func TestProcessApprovalsAndReviewers(t *testing.T) {
 				},
 			}
 
-			var err error
-			if tc.name == "error getting currently requested" {
-				err = nil
-			}
 			success, _, err := app.processApprovalsAndReviewers()
 			if tc.expectError {
 				if err == nil {


### PR DESCRIPTION
## Related PR(s)

<!--
Delete this section if there are no related PRs.
-->

## Related Issue(s)
https://github.com/multimediallc/codeowners-plus/issues/5
<!--
Delete this section if there is no Issue this PR attempts to resolve or make progress on.
-->

## Summary / Background
This PR adds a quiet mode to codeowners plus, which prevents the addition of comments to PRs and will not request reviews from unapproved owners.  This feature should be especially useful for running codeowners on PR's that are still in draft status.

The readme is updated with info on what it does, and how to run in quiet mode.

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

