### PR TITLE
Fix issue where failure message appears before log messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-83.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-83.6%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/main.go
+++ b/main.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
+	"io"
 	"os"
 	"slices"
 	"strconv"
@@ -86,7 +87,7 @@ func initFlags(flags *Flags) error {
 func NewApp(cfg AppConfig) (*App, error) {
 	repoSplit := strings.Split(cfg.Repo, "/")
 	if len(repoSplit) != 2 {
-		return nil, fmt.Errorf("invalid repo name: %s", cfg.Repo)
+		return nil, fmt.Errorf("Invalid repo name: %s", cfg.Repo)
 	}
 	owner := repoSplit[0]
 	repo := repoSplit[1]
@@ -379,19 +380,19 @@ func ignoreError[V any, E error](res V, _ E) V {
 	return res
 }
 
-func errorAndExit(shouldFail bool, format string, args ...interface{}) {
-	_, err := WarningBuffer.WriteTo(os.Stderr)
+func outputAndExit(w io.Writer, shouldFail bool, message string) {
+	_, err := WarningBuffer.WriteTo(w)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error writing warning buffer: %v\n", err)
 	}
 	if *flags.Verbose {
-		_, err := InfoBuffer.WriteTo(os.Stderr)
+		_, err := InfoBuffer.WriteTo(w)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Error writing info buffer: %v\n", err)
 		}
 	}
 
-	fmt.Fprintf(os.Stderr, format, args...)
+	fmt.Fprint(w, message)
 	if testing.Testing() {
 		return
 	}
@@ -415,7 +416,7 @@ func printWarning(format string, args ...interface{}) {
 func main() {
 	err := initFlags(flags)
 	if err != nil {
-		errorAndExit(true, "%v\n", err)
+		outputAndExit(os.Stderr, true, fmt.Sprintln(err))
 	}
 
 	cfg := AppConfig{
@@ -428,29 +429,19 @@ func main() {
 
 	app, err := NewApp(cfg)
 	if err != nil {
-		errorAndExit(true, "Failed to initialize app: %v\n", err)
+		outputAndExit(os.Stderr, true, fmt.Sprintf("Failed to initialize app: %v\n", err))
 	}
 
 	success, message, err := app.Run()
 	if err != nil {
-		errorAndExit(true, "%v\n", err)
+		outputAndExit(os.Stderr, true, fmt.Sprintln(err))
 	}
-	_, err = WarningBuffer.WriteTo(os.Stderr)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error writing warning buffer: %v\n", err)
-	}
-	if *flags.Verbose {
-		_, err = InfoBuffer.WriteTo(os.Stdout)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "Error writing info buffer: %v\n", err)
-		}
-	}
+	var w io.Writer
 	if success {
-		fmt.Fprintln(os.Stdout, message)
+		w = os.Stdout
 	} else {
-		fmt.Fprintln(os.Stderr, message)
+		w = os.Stderr
 	}
-	if !success && app.conf.Enforcement.FailCheck {
-		os.Exit(1)
-	}
+	shouldFail := !success && app.conf.Enforcement.FailCheck
+	outputAndExit(w, shouldFail, message)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -556,7 +556,7 @@ func TestErrorAndExit(t *testing.T) {
 			InfoBuffer.WriteString(tc.info)
 			*flags.Verbose = tc.verbose
 
-			errorAndExit(tc.shouldFail, tc.format, tc.args...)
+			outputAndExit(io.Discard, tc.shouldFail, fmt.Sprintf(tc.format, tc.args...))
 		})
 	}
 }


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

A recent change caused error messages to come out of order with logging due to output target.  While fixing this issue, did a little refactor to reduce duplication.