### PR TITLE
fix: non-owner reviews not counting toward min reviews

### DIFF
--- a/internal/github/gh.go
+++ b/internal/github/gh.go
@@ -228,6 +228,9 @@ func currentReviewerApprovalsFromReviews(approvals []*github.PullRequestReview, 
 		if reviewers, ok := userReviewerMap[reviewingUser]; ok {
 			newApproval := &CurrentApproval{reviewingUser, review.GetID(), reviewers, review.GetCommitID()}
 			filteredApprovals = append(filteredApprovals, newApproval)
+		} else {
+			newApproval := &CurrentApproval{reviewingUser, review.GetID(), []string{}, review.GetCommitID()}
+			filteredApprovals = append(filteredApprovals, newApproval)
 		}
 	}
 

--- a/internal/github/gh_test.go
+++ b/internal/github/gh_test.go
@@ -72,6 +72,7 @@ func TestCurrentApprovalsFromReviews(t *testing.T) {
 	expectedApprovals := []*CurrentApproval{
 		{CommitID: "commit1", Reviewers: []string{"@a", "@b"}},
 		{CommitID: "commit3", Reviewers: []string{"@e"}},
+		{CommitID: "commit3", Reviewers: []string{}},
 	}
 
 	if len(currentApprovals) != len(expectedApprovals) {


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

A bug was reported where a PR had 2 approvals, but didn't pass with 2 min reviews.

The check is currently not counting any approvals which are not from owners.  Changed the logic to count any approval towards minimum.