### PR TITLE
Adds an initial dependabot configuration for `go` and `github-actions`.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      gomod:
+        patterns:
+          - "*"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

This PR adds a dependabot configuration file for automatically checking go dependencies and github actions dependencies on a weekly cadence.

Note that this features does NOT auto-merge. It will open PRs, but maintainers will need to merge them, or bump the dependencies otherwise.

Notably, I did not include the `docker` ecosystem for updates, because it would update the go base image version, which I feel requires more work than dependabot changing that single line for the repo to stay in sync.