### PR TITLE
Reset and explicitly declare permissions in every workflow

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -9,10 +9,15 @@ on:
     branches: [main]
     types: [opened, reopened, synchronize, ready_for_review, labeled, unlabeled]
 
+permissions: {}
+
 jobs:
   codeowners:
     name: 'Run Codeowners Plus'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: 'Checkout Code Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/covbadge.yml
+++ b/.github/workflows/covbadge.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/covbadge.yml
+++ b/.github/workflows/covbadge.yml
@@ -13,7 +13,7 @@ jobs:
     name: 'Check Coverage Badge'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/covbadge.yml
+++ b/.github/workflows/covbadge.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   build-test:
     name: 'Check Coverage Badge'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,7 +13,7 @@ jobs:
     name: 'Go Build & Test'
     runs-on: ubuntu-latest
     permissions:
-      contents: write
+      contents: read
       pull-requests: write
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
+      pull-requests: read
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,10 +6,15 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   build-test:
     name: 'Go Build & Test'
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -4,8 +4,7 @@ on:
   release:
     types: [draft, published]
 
-permissions:
-  contents: write
+permissions: {}
 
 env:
   DOCKER_BUILDKIT: 1
@@ -13,6 +12,9 @@ env:
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,9 +4,14 @@ on:
   release:
     types: [published]
 
+permissions: {}
+
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
     steps:
       - name: 'Checkout Code Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/rerun_codeowners.yml
+++ b/.github/workflows/rerun_codeowners.yml
@@ -4,10 +4,15 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   rerun-codeowners:
     name: 'Rerun Codeowners Plus'
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+      contents: read
     steps:
       - name: 'Checkout Code Repository'
         uses: actions/checkout@v4

--- a/.github/workflows/rerun_codeowners.yml
+++ b/.github/workflows/rerun_codeowners.yml
@@ -11,6 +11,7 @@ jobs:
     name: 'Rerun Codeowners Plus'
     runs-on: ubuntu-latest
     permissions:
+      actions: write
       pull-requests: write
       contents: read
     steps:


### PR DESCRIPTION
## Related Issue(s)

<!--
Delete this section if there is no Issue this PR attempts to resolve or make progress on.
-->

CodeQL scanning complaints here:
- https://github.com/multimediallc/codeowners-plus/security/code-scanning/4
- https://github.com/multimediallc/codeowners-plus/security/code-scanning/6
- https://github.com/multimediallc/codeowners-plus/security/code-scanning/7
- https://github.com/multimediallc/codeowners-plus/security/code-scanning/8
- https://github.com/multimediallc/codeowners-plus/security/code-scanning/9
- https://github.com/multimediallc/codeowners-plus/security/code-scanning/11

## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

This PR looks holistically at all workflows in the repo and makes a similar change, removing the default permissions on `github_token` by setting `permissions: {}` at the workflow level, and then re-adding the permissions with job-level permission blocks. 

I've attempted to determine the permissions the jobs are _likely_, to require, but some adjustment might be necessary (and experimentation for _downscoping_ from this baseline is encouraged)

