### PR TITLE
Remove target flag in favor of positional arguments and add format

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-82.2%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.4%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-84.2%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.2%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/tools/cli/main.go
+++ b/tools/cli/main.go
@@ -304,13 +304,10 @@ func fileOwner(repo string, targets []string, format string) error {
 	switch format {
 	case "json":
 		jsonTargets(targets, ownersMap)
-		break
 	case "default":
 		printTargets(targets, ownersMap, false)
-		break
 	case "one-line":
 		printTargets(targets, ownersMap, true)
-		break
 	}
 
 	return nil


### PR DESCRIPTION
## Related Issue(s)

<!--
Delete this section if there is no Issue this PR attempts to resolve or make progress on.
-->

Address part of #30 

## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

`target` being a flag rather than argument for the cli commands is not really ergonomic, and current implementations required `xargs` to get output for multiple files.

Changing this to use positional arguments is a better API

Additionally, it was requested to provide structured output for programmatic processing.  Added format flag allowing for one-line formatting and json output