### PR TITLE
Add stdin targets to all commands

### DIFF
--- a/.github/workflows/covbadge.yml
+++ b/.github/workflows/covbadge.yml
@@ -24,7 +24,7 @@ jobs:
         go-version: '1.23'
 
     - name: 'Install gobadge'
-      run: go install github.com/AlexBeauchemin/gobadge@v0.3.0
+      run: go install github.com/AlexBeauchemin/gobadge@v0.4.0
 
     - name: 'Run gobadge'
       run: ./scripts/covbadge.sh

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ Available commands are:
 
 * `unowned` to check for unowned files
 * `owner` to check who owns a specific file
-* `verify` to check for typos in a `.codeowners` file
+* `validate` to check for typos in a `.codeowners` file
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-82.1%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.2%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-83.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.1%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
@@ -287,7 +287,7 @@ Even in quiet mode, the tool still performs all its internal calculations: deter
 * **GitHub Action:** Set the `quiet` input to `'true'`.
     ```yaml
     - name: 'Codeowners Plus (Quiet)'
-      uses: multimediallc/codeowners-plus@v0.1.0
+      uses: multimediallc/codeowners-plus@v0.2.0
       with:
         # ... other inputs ...
         quiet: 'true'

--- a/scripts/covbadge.sh
+++ b/scripts/covbadge.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-go install github.com/AlexBeauchemin/gobadge@v0.3.0
+go install github.com/AlexBeauchemin/gobadge@v0.4.0
 
 # fail if gobadge is no installed
 which gobadge

--- a/tools/cli/format.go
+++ b/tools/cli/format.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"fmt"
+	"slices"
+	"strings"
+)
+
+type OutputFormat string
+
+const (
+	FormatDefault OutputFormat = "default"
+	FormatOneLine OutputFormat = "one-line"
+	FormatJSON    OutputFormat = "json"
+)
+
+var allowedFormats = []string{string(FormatDefault), string(FormatOneLine), string(FormatJSON)}
+
+func validateFormat(format string) (OutputFormat, error) {
+	if !slices.Contains(allowedFormats, format) {
+		return "", fmt.Errorf("invalid format %s. Must be one of %s", format, strings.Join(allowedFormats, ", "))
+	}
+	return OutputFormat(format), nil
+}

--- a/tools/cli/format_test.go
+++ b/tools/cli/format_test.go
@@ -1,0 +1,95 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestValidateFormat(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    OutputFormat
+		wantErr bool
+	}{
+		{
+			name:    "valid default format",
+			input:   "default",
+			want:    FormatDefault,
+			wantErr: false,
+		},
+		{
+			name:    "valid one-line format",
+			input:   "one-line",
+			want:    FormatOneLine,
+			wantErr: false,
+		},
+		{
+			name:    "valid json format",
+			input:   "json",
+			want:    FormatJSON,
+			wantErr: false,
+		},
+		{
+			name:    "invalid format",
+			input:   "invalid",
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name:    "empty format",
+			input:   "",
+			want:    "",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := validateFormat(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateFormat() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("validateFormat() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOutputFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		f    OutputFormat
+		want string
+	}{
+		{
+			name: "default format",
+			f:    FormatDefault,
+			want: "default",
+		},
+		{
+			name: "one-line format",
+			f:    FormatOneLine,
+			want: "one-line",
+		},
+		{
+			name: "json format",
+			f:    FormatJSON,
+			want: "json",
+		},
+		{
+			name: "empty format",
+			f:    "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := string(tt.f); got != tt.want {
+				t.Errorf("OutputFormat = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tools/cli/main.go
+++ b/tools/cli/main.go
@@ -165,7 +165,7 @@ func main() {
 					}
 
 					if len(targets) == 0 {
-						fmt.Printf("No target provided, validating root .codeowners")
+						fmt.Println("No target provided, validating root .codeowners")
 						targets = []string{"."}
 					}
 
@@ -236,7 +236,7 @@ func unownedFilesWithFormat(repo string, targets []string, depth int, dirsOnly b
 			if depth != 0 && depthCheck(file, target, depth) {
 				continue
 			}
-			if target != "" && !strings.HasPrefix(file, target) {
+			if target != "" && !strings.HasPrefix(file, fmt.Sprintf("%s/", target)) {
 				continue
 			}
 			files = append(files, codeowners.DiffFile{FileName: file})
@@ -277,7 +277,10 @@ func unownedFilesWithFormat(repo string, targets []string, depth int, dirsOnly b
 		fmt.Println(string(jsonData))
 	case FormatOneLine:
 		for target, files := range results {
-			fmt.Printf("%s: %s\n", target, strings.Join(files, ", "))
+			if len(targets) > 1 {
+				fmt.Printf("%s: ", target)
+			}
+			fmt.Println(strings.Join(files, ", "))
 		}
 	default: // FormatDefault
 		first := true
@@ -286,7 +289,9 @@ func unownedFilesWithFormat(repo string, targets []string, depth int, dirsOnly b
 				fmt.Println()
 			}
 			first = false
-			fmt.Printf("%s:\n", target)
+			if len(targets) > 1 {
+				fmt.Printf("%s:\n", target)
+			}
 			for _, file := range files {
 				fmt.Println(file)
 			}

--- a/tools/cli/main.go
+++ b/tools/cli/main.go
@@ -141,7 +141,7 @@ func main() {
 				Name:        "validate",
 				Aliases:     []string{"v", "verify"},
 				Usage:       "Validate the `.codeowners` file format",
-				UsageText:   "codeowners-cli verify [options] <directory1> [directory2]...\n   or: cat dirs.txt | codeowners-cli verify [options]",
+				UsageText:   "codeowners-cli validate [options] <directory1> [directory2]...\n   or: cat dirs.txt | codeowners-cli validate [options]",
 				Description: "Validate the `.codeowners` file in the specified directories. Multiple directories can be specified as arguments or piped from stdin (one directory per line). Each directory must contain a `.codeowners` file.",
 				Flags: []cli.Flag{
 					&cli.StringFlag{
@@ -171,7 +171,7 @@ func main() {
 
 					var allErrors []string
 					for _, target := range targets {
-						if err := verifyCodeowners(repo, target); err != nil {
+						if err := validateCodeowners(repo, target); err != nil {
 							allErrors = append(allErrors, fmt.Sprintf("%s: %v", target, err))
 						}
 					}
@@ -408,7 +408,7 @@ func fileOwner(repo string, targets []string, format OutputFormat) error {
 	return nil
 }
 
-func verifyCodeowners(repo string, target string) error {
+func validateCodeowners(repo string, target string) error {
 	if repoStat, err := os.Lstat(repo); err != nil || !repoStat.IsDir() {
 		return fmt.Errorf("root is not a directory: %s", repo)
 	}

--- a/tools/cli/main_test.go
+++ b/tools/cli/main_test.go
@@ -257,7 +257,7 @@ func TestFileOwner(t *testing.T) {
 	}
 }
 
-func TestVerifyCodeowners(t *testing.T) {
+func TestValidateCodeowners(t *testing.T) {
 	testRepo, cleanup := setupTestRepo(t)
 	defer cleanup()
 
@@ -306,14 +306,14 @@ func TestVerifyCodeowners(t *testing.T) {
 				}
 			}
 
-			err := verifyCodeowners(testRepo, tc.target)
+			err := validateCodeowners(testRepo, tc.target)
 			if (err != nil) != tc.wantErr {
-				t.Errorf("verifyCodeowners() error = %v, wantErr %v", err, tc.wantErr)
+				t.Errorf("validateCodeowners() error = %v, wantErr %v", err, tc.wantErr)
 				return
 			}
 
 			if tc.wantErr && tc.errMatch != "" && !strings.Contains(err.Error(), tc.errMatch) {
-				t.Errorf("verifyCodeowners() error = %v, want to contain %v", err, tc.errMatch)
+				t.Errorf("validateCodeowners() error = %v, want to contain %v", err, tc.errMatch)
 			}
 		})
 	}

--- a/tools/cli/stdin.go
+++ b/tools/cli/stdin.go
@@ -1,0 +1,33 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// isStdinPiped checks if stdin is being piped to the program
+func isStdinPiped() bool {
+	stat, err := os.Stdin.Stat()
+	if err != nil {
+		return false
+	}
+	return (stat.Mode() & os.ModeCharDevice) == 0
+}
+
+// scanStdin reads input from stdin and returns a slice of non-empty lines
+func scanStdin() ([]string, error) {
+	scanner := bufio.NewScanner(os.Stdin)
+	var lines []string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			lines = append(lines, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("error reading from stdin: %w", err)
+	}
+	return lines, nil
+}

--- a/tools/cli/stdin_test.go
+++ b/tools/cli/stdin_test.go
@@ -58,7 +58,9 @@ func TestScanStdin(t *testing.T) {
 			os.Stdin = r
 
 			go func() {
-				defer w.Close()
+				defer func() {
+					_ = w.Close()
+				}()
 				if _, err := w.Write([]byte(tt.input)); err != nil {
 					t.Errorf("Failed to write to pipe: %v", err)
 				}

--- a/tools/cli/stdin_test.go
+++ b/tools/cli/stdin_test.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsStdinPiped(t *testing.T) {
+	if isStdinPiped() {
+		t.Error("IsStdinPiped() returned true when stdin is not piped")
+	}
+}
+
+func TestScanStdin(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{
+			name:     "empty input",
+			input:    "",
+			expected: []string{},
+		},
+		{
+			name:     "single line",
+			input:    "test",
+			expected: []string{"test"},
+		},
+		{
+			name:     "multiple lines",
+			input:    "line1\nline2\nline3",
+			expected: []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "lines with whitespace",
+			input:    "  line1  \n\tline2\t\n  line3  ",
+			expected: []string{"line1", "line2", "line3"},
+		},
+		{
+			name:     "empty lines",
+			input:    "line1\n\nline2\n\n\nline3",
+			expected: []string{"line1", "line2", "line3"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Save original stdin and restore it after the test
+			oldStdin := os.Stdin
+			defer func() { os.Stdin = oldStdin }()
+
+			// Create a pipe and set it as stdin
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatalf("Failed to create pipe: %v", err)
+			}
+			os.Stdin = r
+
+			go func() {
+				defer w.Close()
+				if _, err := w.Write([]byte(tt.input)); err != nil {
+					t.Errorf("Failed to write to pipe: %v", err)
+				}
+			}()
+
+			got, err := scanStdin()
+			if err != nil {
+				t.Errorf("ScanStdin() error = %v", err)
+				return
+			}
+
+			if len(got) != len(tt.expected) {
+				t.Errorf("ScanStdin() got %d lines, want %d", len(got), len(tt.expected))
+				return
+			}
+
+			for i, line := range got {
+				if line != tt.expected[i] {
+					t.Errorf("ScanStdin() line %d = %q, want %q", i, line, tt.expected[i])
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Related PR(s)

<!--
Delete this section if there are no related PRs.
-->

- #33

## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

Adds ability to pipe input to stdin of the cli commands for convenience.

Also adds formatting to `unowned` command, similar to `owner` command