### PR TITLE
Export Codeowners Plus information to JSON data for ingestion

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -30,9 +30,26 @@ jobs:
           cat action.yml
 
       - name: 'Codeowners Plus'
+        id: codeowners-plus
         uses: ./
         with:
           github-token: '${{ secrets.GITHUB_TOKEN }}'
           pr: '${{ github.event.pull_request.number }}'
           verbose: true
           quiet: ${{ github.event.pull_request.draft }}
+
+      - name: Create Check Run with JSON Output
+        env:
+          REPORT_JSON: ${{ steps.codeowners-plus.outputs.data }}
+        run: |
+          # Use the 'gh' CLI to interact with the GitHub API
+          gh api --method POST \
+            -H "Accept: application/vnd.github+json" \
+            "/repos/${{ github.repository }}/check-runs" \
+            -f name='Codeowners Plus Report' \
+            -f head_sha='${{ github.event.pull_request.head.sha || github.sha }}' \
+            -f status='completed' \
+            -f conclusion='success' \
+            -f output.title='Codeowners Plus Report' \
+            -f output.summary="Codeowners Plus analysis JSON data including file owners and results" \
+            -f "output.text=$REPORT_JSON"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-82.2%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-80.9%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,10 @@ inputs:
     required: false
     default: false
 
+outputs:
+  data:
+    description: 'JSON string containing all the codeowners data (success, message, file-owners, file-optional, still-required)'
+
 runs:
   using: 'docker'
   image: 'docker://ghcr.io/multimediallc/codeowners-plus:latest'

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -962,7 +962,7 @@ func TestProcessApprovalsAndReviewers(t *testing.T) {
 				},
 			}
 
-			success, _, err := app.processApprovalsAndReviewers()
+			success, _, _, err := app.processApprovalsAndReviewers()
 			if tc.expectError {
 				if err == nil {
 					t.Error("expected error but got none")


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

Some changes either on GH's CDN end or Chrome Cors enforcement has broken our internal browser extension tool.

The tool was pulling the logs of the workflow.

We can avoid pulling logs by exposing the underlying data as a Check Run output instead. 