### PR TITLE
Fix OutputData file_required being cleared by approvals

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-81.9%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-81.8%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1110,7 +1110,8 @@ func TestBuildOutputData(t *testing.T) {
 	message := "Test message"
 	stillRequired := []string{"@user1"}
 
-	output := app.buildOutputData(success, message, stillRequired)
+	output := NewOutputData(app.codeowners)
+	output.UpdateOutputData(success, message, stillRequired)
 
 	if !output.Success {
 		t.Errorf("expected Success true, got false")

--- a/main.go
+++ b/main.go
@@ -97,7 +97,7 @@ func outputAndExit(w io.Writer, shouldFail bool, message string) {
 }
 
 // writeGITHUBOUTPUT writes the OutputData to the GITHUB_OUTPUT file in the correct format
-func writeGITHUBOUTPUT(outputData app.OutputData) error {
+func writeGITHUBOUTPUT(outputData *app.OutputData) error {
 	githubOutput := os.Getenv("GITHUB_OUTPUT")
 	if githubOutput == "" {
 		return nil // No GITHUB_OUTPUT environment variable set

--- a/main_test.go
+++ b/main_test.go
@@ -240,7 +240,7 @@ func TestGITHUBOUTPUT(t *testing.T) {
 		_ = os.Setenv("GITHUB_OUTPUT", tmpFile.Name())
 
 		// Test data
-		testOutputData := app.OutputData{
+		testOutputData := &app.OutputData{
 			FileOwners: map[string][]string{
 				"file1.go": {"@user1", "@user2"},
 				"file2.go": {"@user3"},
@@ -322,7 +322,7 @@ func TestGITHUBOUTPUT(t *testing.T) {
 		_ = os.Unsetenv("GITHUB_OUTPUT")
 
 		// Test data
-		testOutputData := app.OutputData{
+		testOutputData := &app.OutputData{
 			FileOwners: map[string][]string{
 				"file1.go": {"@user1"},
 			},


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

Approvals are causing OutputData's file_required to be cleared due to processing approvals before populating the field.
Changing order so file_required captures the starting values rather than ending values.