### PR TITLE
Add admin bypass feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-81.8%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-81.6%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
@@ -43,6 +43,7 @@ Instead, this tool uses comments to communicate who the required reviews are, an
 These are features missing from GitHub code owners that are supported by Codeowners Plus:
 
 * Smart dismissal of stale reviews (only dismiss review when owned files change, rather than any reviewable push)
+* Admin bypass functionality for emergency overrides by repository administrators
 * Supports multiple owners of files (`AND` ownership rules)
   * GitHub CODEOWNERS supports only `OR` ownership rules, in contrast
 * Directory-level code ownership files to assign fine-grained code ownership
@@ -227,6 +228,14 @@ high_priority_labels = ["high-priority", "urgent"]
 # `enforcement` allows you to specify how the Codeowners Plus check should be enforced
 [enforcement]
 # see "Enforcement Options" below for more details
+
+# `admin_bypass` allows repository administrators to bypass codeowner requirements
+[admin_bypass]
+enabled = true          # Enable admin bypass functionality  
+allowed_users = [       # Specific users allowed to bypass (in addition to repo admins)
+  "emergency-contact",
+  "release-manager"
+]
 ```
 
 When a PR has any of the `high_priority_labels`, the comment will look like this:
@@ -268,6 +277,32 @@ With this setup, `@token-owner` will be a GitHub code owner on every PR, and Cod
 
 Unfortunately, `CODEOWNERS` does not support apps/bots as owners despite there being an [active discussion requesting the feature since 2020](https://github.com/orgs/community/discussions/23064).
 Hopefully GitHub adds support for apps/bots as codeowners so this option can become viable for non-org repos.
+
+#### Admin Bypass
+
+Repository administrators can bypass all codeowner requirements in emergency situations by creating a special approval review containing "Codeowners Bypass" text. This feature:
+
+- **Requires authorization**: Only repository admins or users listed in `admin_bypass.allowed_users` can create valid bypass approvals
+- **Guarantee success**: When detected, the PR passes all codeowner checks regardless of missing approvals
+- **Audit trail**: Creates a clear record of who bypassed requirements and when
+
+To use the admin bypass feature:
+
+1. **Enable it in `codeowners.toml`**:
+   ```toml
+   [admin_bypass]
+   enabled = true
+   allowed_users = ["emergency-contact", "release-manager"]  # Optional specific users
+   ```
+
+2. **Create an approval review containing "Codeowners Bypass"** text. This can be done by:
+   - Repository administrators manually approving the PR with "Codeowners Bypass" in their review comment
+   - Users listed in `allowed_users` manually approving with the bypass text
+   - Automated workflows that create approval reviews with the bypass text on behalf of authorized users
+
+3. **Codeowners Plus automatically detects and validates** the bypass approval, immediately marking the PR as passing all codeowner requirements.
+
+The bypass text is case-insensitive, so "codeowners bypass", "Codeowners Bypass", or "CODEOWNERS BYPASS" all work.
 
 ### Quiet Mode
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,11 +15,17 @@ type Config struct {
 	Ignore               []string     `toml:"ignore"`
 	Enforcement          *Enforcement `toml:"enforcement"`
 	HighPriorityLabels   []string     `toml:"high_priority_labels"`
+	AdminBypass          *AdminBypass `toml:"admin_bypass"`
 }
 
 type Enforcement struct {
 	Approval  bool `toml:"approval"`
 	FailCheck bool `toml:"fail_check"`
+}
+
+type AdminBypass struct {
+	Enabled       bool     `toml:"enabled"`
+	AllowedUsers  []string `toml:"allowed_users"`
 }
 
 func ReadConfig(path string) (*Config, error) {
@@ -34,6 +40,7 @@ func ReadConfig(path string) (*Config, error) {
 		Ignore:               []string{},
 		Enforcement:          &Enforcement{Approval: false, FailCheck: true},
 		HighPriorityLabels:   []string{},
+		AdminBypass:          &AdminBypass{Enabled: false, AllowedUsers: []string{}},
 	}
 
 	fileName := path + "codeowners.toml"
@@ -51,6 +58,9 @@ func ReadConfig(path string) (*Config, error) {
 	}
 	if config.Enforcement == nil {
 		config.Enforcement = defaultConfig.Enforcement
+	}
+	if config.AdminBypass == nil {
+		config.AdminBypass = defaultConfig.AdminBypass
 	}
 	return config, nil
 }

--- a/internal/github/gh_test.go
+++ b/internal/github/gh_test.go
@@ -3,6 +3,7 @@ package gh
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -1287,5 +1288,289 @@ func TestUpdateComment(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 		})
+	}
+}
+
+func TestContainsValidBypassApproval(t *testing.T) {
+	tt := []struct {
+		name         string
+		reviews      []*github.PullRequestReview
+		allowedUsers []string
+		adminUsers   []string
+		expected     bool
+		expectError  bool
+	}{
+		{
+			name: "admin user with bypass text",
+			reviews: []*github.PullRequestReview{
+				{
+					ID:   github.Int64(123),
+					Body: github.String("🔓 Codeowners Bypass Approved by admin"),
+					User: &github.User{Login: github.String("admin-user")},
+				},
+			},
+			allowedUsers: []string{},
+			adminUsers:   []string{"admin-user"},
+			expected:     true,
+			expectError:  false,
+		},
+		{
+			name: "allowed user with bypass text",
+			reviews: []*github.PullRequestReview{
+				{
+					ID:   github.Int64(124),
+					Body: github.String("Emergency bypass - codeowners bypass"),
+					User: &github.User{Login: github.String("emergency-user")},
+				},
+			},
+			allowedUsers: []string{"emergency-user"},
+			adminUsers:   []string{},
+			expected:     true,
+			expectError:  false,
+		},
+		{
+			name: "non-admin user with bypass text",
+			reviews: []*github.PullRequestReview{
+				{
+					ID:   github.Int64(125),
+					Body: github.String("codeowners bypass"),
+					User: &github.User{Login: github.String("regular-user")},
+				},
+			},
+			allowedUsers: []string{},
+			adminUsers:   []string{},
+			expected:     false,
+			expectError:  false,
+		},
+		{
+			name: "admin user without bypass text",
+			reviews: []*github.PullRequestReview{
+				{
+					ID:   github.Int64(126),
+					Body: github.String("LGTM"),
+					User: &github.User{Login: github.String("admin-user")},
+				},
+			},
+			allowedUsers: []string{},
+			adminUsers:   []string{"admin-user"},
+			expected:     false,
+			expectError:  false,
+		},
+		{
+			name: "case insensitive bypass text",
+			reviews: []*github.PullRequestReview{
+				{
+					ID:   github.Int64(127),
+					Body: github.String("CODEOWNERS BYPASS"),
+					User: &github.User{Login: github.String("admin-user")},
+				},
+			},
+			allowedUsers: []string{},
+			adminUsers:   []string{"admin-user"},
+			expected:     true,
+			expectError:  false,
+		},
+		{
+			name: "multiple reviews with one bypass",
+			reviews: []*github.PullRequestReview{
+				{
+					ID:   github.Int64(128),
+					Body: github.String("LGTM"),
+					User: &github.User{Login: github.String("regular-user")},
+				},
+				{
+					ID:   github.Int64(129),
+					Body: github.String("codeowners bypass"),
+					User: &github.User{Login: github.String("admin-user")},
+				},
+			},
+			allowedUsers: []string{},
+			adminUsers:   []string{"admin-user"},
+			expected:     true,
+			expectError:  false,
+		},
+		{
+			name:         "no reviews",
+			reviews:      []*github.PullRequestReview{},
+			allowedUsers: []string{},
+			adminUsers:   []string{},
+			expected:     false,
+			expectError:  false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, gh := mockServerAndClient(t)
+			defer server.Close()
+
+			gh.pr = &github.PullRequest{Number: github.Int(123)}
+			gh.reviews = tc.reviews
+
+			// Mock the admin permission check
+			for _, adminUser := range tc.adminUsers {
+				mux.HandleFunc(fmt.Sprintf("/repos/test-owner/test-repo/collaborators/%s/permission", adminUser), func(w http.ResponseWriter, r *http.Request) {
+					response := map[string]interface{}{
+						"permission": "admin",
+					}
+					w.Header().Set("Content-Type", "application/json")
+					json.NewEncoder(w).Encode(response)
+				})
+			}
+
+			// Mock non-admin users
+			for _, review := range tc.reviews {
+				userName := review.User.GetLogin()
+				isAdmin := false
+				for _, adminUser := range tc.adminUsers {
+					if userName == adminUser {
+						isAdmin = true
+						break
+					}
+				}
+				if !isAdmin {
+					mux.HandleFunc(fmt.Sprintf("/repos/test-owner/test-repo/collaborators/%s/permission", userName), func(w http.ResponseWriter, r *http.Request) {
+						response := map[string]interface{}{
+							"permission": "write",
+						}
+						w.Header().Set("Content-Type", "application/json")
+						json.NewEncoder(w).Encode(response)
+					})
+				}
+			}
+
+			result, err := gh.ContainsValidBypassApproval(tc.allowedUsers)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected an error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestContainsValidBypassApprovalNoPR(t *testing.T) {
+	gh := NewClient("test-owner", "test-repo", "test-token").(*GHClient)
+	
+	result, err := gh.ContainsValidBypassApproval([]string{})
+	
+	if err == nil {
+		t.Error("expected NoPRError, got nil")
+	}
+	
+	if result {
+		t.Error("expected false result when no PR is set")
+	}
+	
+	var noPRErr *NoPRError
+	if !errors.As(err, &noPRErr) {
+		t.Errorf("expected NoPRError, got %T", err)
+	}
+}
+
+func TestIsRepositoryAdmin(t *testing.T) {
+	tt := []struct {
+		name         string
+		username     string
+		permission   string
+		expected     bool
+		expectError  bool
+	}{
+		{
+			name:        "admin user",
+			username:    "admin-user",
+			permission:  "admin",
+			expected:    true,
+			expectError: false,
+		},
+		{
+			name:        "write user",
+			username:    "write-user", 
+			permission:  "write",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "read user",
+			username:    "read-user",
+			permission:  "read",
+			expected:    false,
+			expectError: false,
+		},
+		{
+			name:        "maintain user",
+			username:    "maintain-user",
+			permission:  "maintain",
+			expected:    false,
+			expectError: false,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			mux, server, gh := mockServerAndClient(t)
+			defer server.Close()
+
+			mux.HandleFunc(fmt.Sprintf("/repos/test-owner/test-repo/collaborators/%s/permission", tc.username), func(w http.ResponseWriter, r *http.Request) {
+				if tc.expectError {
+					w.WriteHeader(http.StatusNotFound)
+					return
+				}
+				
+				response := map[string]interface{}{
+					"permission": tc.permission,
+				}
+				w.Header().Set("Content-Type", "application/json")
+				json.NewEncoder(w).Encode(response)
+			})
+
+			result, err := gh.IsRepositoryAdmin(tc.username)
+
+			if tc.expectError {
+				if err == nil {
+					t.Error("expected an error, got nil")
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+
+			if result != tc.expected {
+				t.Errorf("expected %v, got %v", tc.expected, result)
+			}
+		})
+	}
+}
+
+func TestIsRepositoryAdminError(t *testing.T) {
+	mux, server, gh := mockServerAndClient(t)
+	defer server.Close()
+
+	mux.HandleFunc("/repos/test-owner/test-repo/collaborators/error-user/permission", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	result, err := gh.IsRepositoryAdmin("error-user")
+	
+	if err == nil {
+		t.Error("expected an error, got nil")
+	}
+	
+	if result {
+		t.Error("expected false result on error")
 	}
 }


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

We sometimes have scenarios at Multi Media where we want to bypass codeowners requirements for certain PRs.  We can bypass all requirements and merge, but this doesn't allow use of the merge queue.  This PR adds the feature to bypass required reviews when an admin or list of approved users comments with the text `Codeowners Bypass`