### PR TITLE
feat: add detailed file reviewer section to comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-81.6%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-81.7%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/README.md
+++ b/README.md
@@ -225,6 +225,10 @@ ignore = ["test_project"]
 #  when one of these PR labels is present
 high_priority_labels = ["high-priority", "urgent"]
 
+# `detailed_reviewers` (default false) means the codeowners will include a collapsible list 
+# of files and owners in its review comment
+detailed_reviewers = true
+
 # `enforcement` allows you to specify how the Codeowners Plus check should be enforced
 [enforcement]
 # see "Enforcement Options" below for more details

--- a/codeowners.toml
+++ b/codeowners.toml
@@ -8,8 +8,8 @@ unskippable_reviewers = ["@BakerNet"]
 ignore = ["test_project"]
 # `high_priority_lables` allows you to specify labels that should be considered high priority
 high_priority_labels = ["P0"]
-# `detailed_owners` (default false) means the codeowners will include a collapsible list of files and owners in its review comment
-detailed_owners = false
+# `detailed_reviewers` (default false) means the codeowners will include a collapsible list of files and owners in its review comment
+detailed_reviewers = false
 
 # `enforcement` allows you to specify how the codeowners check should be enforced
 [enforcement]

--- a/codeowners.toml
+++ b/codeowners.toml
@@ -8,6 +8,8 @@ unskippable_reviewers = ["@BakerNet"]
 ignore = ["test_project"]
 # `high_priority_lables` allows you to specify labels that should be considered high priority
 high_priority_labels = ["P0"]
+# `detailed_owners` (default false) means the codeowners will include a collapsible list of files and owners in its review comment
+detailed_owners = false
 
 # `enforcement` allows you to specify how the codeowners check should be enforced
 [enforcement]

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -288,7 +288,7 @@ func (a *App) addReviewStatusComment(allRequiredOwners codeowners.ReviewerGroups
 		comment += "\n\nThe PR has received the max number of required reviews. No further action is required."
 	}
 
-	if a.Conf.DetailedOwners {
+	if a.Conf.DetailedReviewers {
 		comment += "\n\n<details><summary>Show detailed file reviewers</summary>\n"
 		comment += a.getFileOwnersMapToString(a.codeowners.FileRequired())
 		comment += "</details>"

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -427,7 +427,6 @@ func (a *App) requestReviews() error {
 }
 
 func (a *App) printFileOwners(codeOwners codeowners.CodeOwners) {
-	codeOwners.FileRequired()
 	a.printDebug("File Reviewers:\n")
 	a.printDebug(a.getFileOwnersMapToString(codeOwners.FileRequired()))
 	a.printDebug("File Optional:\n")
@@ -435,9 +434,10 @@ func (a *App) printFileOwners(codeOwners codeowners.CodeOwners) {
 }
 
 func (a *App) getFileOwnersMapToString(fileReviewers map[string]codeowners.ReviewerGroups) string {
-	output := ""
+	builder := strings.Builder{}
 	for file, reviewers := range fileReviewers {
-		output += fmt.Sprintf("- %s: %+v\n", file, reviewers.Flatten())
+		// builder.WriteString error return is always nil
+		_, _ = fmt.Fprintf(&builder, "- %s: %+v\n", file, reviewers.Flatten())
 	}
-	return output
+	return builder.String()
 }

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -289,8 +289,8 @@ func (a *App) addReviewStatusComment(allRequiredOwners codeowners.ReviewerGroups
 	}
 
 	if a.Conf.DetailedOwners {
-		comment += "\n\n<details><summary>Show detailed required file reviewers</summary>"
-		comment += a.getFileOwnersString(a.codeowners.FileRequired())
+		comment += "\n\n<details><summary>Show detailed file reviewers</summary>\n"
+		comment += a.getFileOwnersMapToString(a.codeowners.FileRequired())
 		comment += "</details>"
 	}
 
@@ -429,12 +429,12 @@ func (a *App) requestReviews() error {
 func (a *App) printFileOwners(codeOwners codeowners.CodeOwners) {
 	codeOwners.FileRequired()
 	a.printDebug("File Reviewers:\n")
-	a.printDebug(a.getFileOwnersString(codeOwners.FileRequired()))
+	a.printDebug(a.getFileOwnersMapToString(codeOwners.FileRequired()))
 	a.printDebug("File Optional:\n")
-	a.printDebug(a.getFileOwnersString(codeOwners.FileOptional()))
+	a.printDebug(a.getFileOwnersMapToString(codeOwners.FileOptional()))
 }
 
-func (a *App) getFileOwnersString(fileReviewers map[string]codeowners.ReviewerGroups) string {
+func (a *App) getFileOwnersMapToString(fileReviewers map[string]codeowners.ReviewerGroups) string {
 	output := ""
 	for file, reviewers := range fileReviewers {
 		output += fmt.Sprintf("- %s: %+v\n", file, reviewers.Flatten())

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1133,18 +1133,18 @@ func TestBuildOutputData(t *testing.T) {
 	}
 }
 
-func TestCommentDetailedOwners(t *testing.T) {
+func TestCommentDetailedReviewers(t *testing.T) {
 	tt := []struct {
-		name               string
-		detailedCodeowners bool
+		name              string
+		detailedReviewers bool
 	}{
 		{
-			name:               "exclude detailed owners when config off",
-			detailedCodeowners: false,
+			name:              "exclude detailed owners when config off",
+			detailedReviewers: false,
 		},
 		{
-			name:               "include detailed owners when config on",
-			detailedCodeowners: true,
+			name:              "include detailed owners when config on",
+			detailedReviewers: true,
 		},
 	}
 
@@ -1174,7 +1174,7 @@ func TestCommentDetailedOwners(t *testing.T) {
 				},
 				Conf: &owners.Config{
 					HighPriorityLabels: []string{},
-					DetailedOwners:     tc.detailedCodeowners,
+					DetailedReviewers:  tc.detailedReviewers,
 				},
 			}
 			err := app.addReviewStatusComment(requiredOwners, false)
@@ -1182,15 +1182,15 @@ func TestCommentDetailedOwners(t *testing.T) {
 				t.Errorf("unexpected error: %v", err)
 			}
 
-			detailedOwnersSnippet := "\n\n<details><summary>Show detailed file reviewers</summary>\n" +
+			DetailedReviewersSnippet := "\n\n<details><summary>Show detailed file reviewers</summary>\n" +
 				"- file1.go: [@user1 @user2]\n" +
 				"- file2.go: [@user1]\n"
 
-			containsDetailedOwnersSnippet := strings.Contains(mockGH.AddCommentInput, detailedOwnersSnippet)
+			containsDetailedReviewersSnippet := strings.Contains(mockGH.AddCommentInput, DetailedReviewersSnippet)
 
-			if tc.detailedCodeowners != containsDetailedOwnersSnippet {
+			if tc.detailedReviewers != containsDetailedReviewersSnippet {
 				t.Errorf("expected comment to include detailed owners to be %t, got %t ",
-					tc.detailedCodeowners, containsDetailedOwnersSnippet)
+					tc.detailedReviewers, containsDetailedReviewersSnippet)
 			}
 
 		})

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ type Config struct {
 	Ignore               []string     `toml:"ignore"`
 	Enforcement          *Enforcement `toml:"enforcement"`
 	HighPriorityLabels   []string     `toml:"high_priority_labels"`
+	DetailedOwners       bool         `toml:"detailed_owners"`
 }
 
 type Enforcement struct {
@@ -34,6 +35,7 @@ func ReadConfig(path string) (*Config, error) {
 		Ignore:               []string{},
 		Enforcement:          &Enforcement{Approval: false, FailCheck: true},
 		HighPriorityLabels:   []string{},
+		DetailedOwners:       false,
 	}
 
 	fileName := path + "codeowners.toml"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,7 +15,7 @@ type Config struct {
 	Ignore               []string     `toml:"ignore"`
 	Enforcement          *Enforcement `toml:"enforcement"`
 	HighPriorityLabels   []string     `toml:"high_priority_labels"`
-	DetailedOwners       bool         `toml:"detailed_owners"`
+	DetailedReviewers    bool         `toml:"detailed_reviewers"`
 }
 
 type Enforcement struct {
@@ -35,7 +35,7 @@ func ReadConfig(path string) (*Config, error) {
 		Ignore:               []string{},
 		Enforcement:          &Enforcement{Approval: false, FailCheck: true},
 		HighPriorityLabels:   []string{},
-		DetailedOwners:       false,
+		DetailedReviewers:    false,
 	}
 
 	fileName := path + "codeowners.toml"

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,6 +37,7 @@ ignore = ["ignored/"]
 approval = true
 fail_check = false
 high_priority_labels = ["high-priority", "urgent"]
+detailed_owners = true
 `,
 			path: "testdata/",
 			expected: &Config{
@@ -46,6 +47,7 @@ high_priority_labels = ["high-priority", "urgent"]
 				Ignore:               []string{"ignored/"},
 				Enforcement:          &Enforcement{Approval: true, FailCheck: false},
 				HighPriorityLabels:   []string{"high-priority", "urgent"},
+				DetailedOwners:       true,
 			},
 			expectedErr: false,
 		},
@@ -63,6 +65,7 @@ unskippable_reviewers = ["@user1"]
 				Ignore:               []string{},
 				Enforcement:          &Enforcement{Approval: false, FailCheck: true},
 				HighPriorityLabels:   []string{},
+				DetailedOwners:       false,
 			},
 			expectedErr: false,
 		},

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -37,7 +37,7 @@ ignore = ["ignored/"]
 approval = true
 fail_check = false
 high_priority_labels = ["high-priority", "urgent"]
-detailed_owners = true
+detailed_reviewers = true
 `,
 			path: "testdata/",
 			expected: &Config{
@@ -47,7 +47,7 @@ detailed_owners = true
 				Ignore:               []string{"ignored/"},
 				Enforcement:          &Enforcement{Approval: true, FailCheck: false},
 				HighPriorityLabels:   []string{"high-priority", "urgent"},
-				DetailedOwners:       true,
+				DetailedReviewers:    true,
 			},
 			expectedErr: false,
 		},
@@ -65,7 +65,7 @@ unskippable_reviewers = ["@user1"]
 				Ignore:               []string{},
 				Enforcement:          &Enforcement{Approval: false, FailCheck: true},
 				HighPriorityLabels:   []string{},
-				DetailedOwners:       false,
+				DetailedReviewers:    false,
 			},
 			expectedErr: false,
 		},


### PR DESCRIPTION
## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

Adds a new `detailed_reviewers` boolean option in `codeowners.toml` (defaults to `false`). Setting to `true` adds a collapsible section in the required reviews comment. Expanding the section shows a list of changed files with the associated reviewers.