### PR TITLE
fix: rerun_codeowners checks read permission, don't checkout repo

### DIFF
--- a/.github/workflows/rerun_codeowners.yml
+++ b/.github/workflows/rerun_codeowners.yml
@@ -2,7 +2,7 @@ name: 'Rerun Code Owners'
 
 on:
   pull_request_review:
-    types: [submitted]
+    types: [submitted, dismissed]
 
 permissions: {}
 
@@ -13,11 +13,8 @@ jobs:
     permissions:
       actions: write
       pull-requests: write
-      contents: read
+      checks: read
     steps:
-      - name: 'Checkout Code Repository'
-        uses: actions/checkout@v4
-      
       - name: 'Rerun Checks'
         uses: shqear93/rerun-checks@cafa5c1c11c880f9b23e6a73ad8628483fdae798  # @v3
         with:


### PR DESCRIPTION
## Related PR(s)

## Related Issue(s)

## Summary / Background

The example `rerun_codeowners.yml` workflow is missing the `checks: read` permission, which `shqear93/rerun-checks` needs. The workflow has an unnecessary checkout step, so delete it and its `contents: read` permission. Lastly, it is possible that an approval can be dismissed, so the workflow should rerun in this case to make codeowners-plus fail from the loss of a required approval.
