### PR TITLE
Add owners for deleted files

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-81.6%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-81.7%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -110,6 +110,33 @@ func TestNewDiff(t *testing.T) {
 				"file2.go": 1,
 			},
 		},
+		{
+			name: "ignore deleted files in ignored directories",
+			context: DiffContext{
+				Base:       "main",
+				Head:       "feature",
+				Dir:        ".",
+				IgnoreDirs: []string{"ignored/"},
+			},
+			mockOutput: `diff --git a/file1.go b/file1.go
+index abc..def 100644
+--- a/file1.go
++++ b/file1.go
+@@ -10,0 +11 @@ func Example() {
++       fmt.Println("New line")
+diff --git a/ignored/deleted.go b/dev/null
+deleted file mode 100644
+index ghi..0000000
+--- a/ignored/deleted.go
++++ /dev/null
+@@ -1 +0,0 @@
+-content`,
+			expectedErr:   false,
+			expectedFiles: 1,
+			expectedHunks: map[string]int{
+				"file1.go": 1,
+			},
+		},
 	}
 
 	for _, tc := range tt {
@@ -384,6 +411,94 @@ func TestToDiffFiles(t *testing.T) {
 						{
 							Start: 30,
 							End:   30,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "deleted file",
+			fileDiffs: []*diff.FileDiff{
+				{
+					OrigName: "a/deleted.go",
+					NewName:  "/dev/null",
+					Hunks: []*diff.Hunk{
+						{
+							NewStartLine: 0,
+							NewLines:     0,
+						},
+					},
+				},
+			},
+			expected: []codeowners.DiffFile{
+				{
+					FileName: "deleted.go",
+					Hunks: []codeowners.HunkRange{
+						{
+							Start: 0,
+							End:   -1,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "mixed: added, modified, and deleted files",
+			fileDiffs: []*diff.FileDiff{
+				{
+					NewName: "b/added.go",
+					Hunks: []*diff.Hunk{
+						{
+							NewStartLine: 1,
+							NewLines:     5,
+						},
+					},
+				},
+				{
+					NewName: "b/modified.go",
+					Hunks: []*diff.Hunk{
+						{
+							NewStartLine: 10,
+							NewLines:     2,
+						},
+					},
+				},
+				{
+					OrigName: "a/deleted.go",
+					NewName:  "/dev/null",
+					Hunks: []*diff.Hunk{
+						{
+							NewStartLine: 0,
+							NewLines:     0,
+						},
+					},
+				},
+			},
+			expected: []codeowners.DiffFile{
+				{
+					FileName: "added.go",
+					Hunks: []codeowners.HunkRange{
+						{
+							Start: 1,
+							End:   5,
+						},
+					},
+				},
+				{
+					FileName: "modified.go",
+					Hunks: []codeowners.HunkRange{
+						{
+							Start: 10,
+							End:   11,
+						},
+					},
+				},
+				{
+					FileName: "deleted.go",
+					Hunks: []codeowners.HunkRange{
+						{
+							Start: 0,
+							End:   -1,
 						},
 					},
 				},


### PR DESCRIPTION
## Related Issue(s)

<!--
Delete this section if there is no Issue this PR attempts to resolve or make progress on.
-->

Closes #69 

## Summary / Background

<!--
Use this section to give a high level overview of the "why" and "what" for your changes.
-->

Currently, deleted files are essentially ignored by Codeowners Plus.  This PR makes it so the old filename is used when a file is deleted for the purpose of assigning owners.