### PR TITLE
Add option to suppress unowned file warning.

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,10 @@ disable_smart_dismissal = true
 # This is useful for ownership handoffs where both the outgoing and incoming teams must review
 require_both_branch_reviewers = false
 
+# `suppress_unowned_warning` (default false) suppresses the warning messages about unowned files
+# Useful when you intentionally have files without codeowners
+suppress_unowned_warning = true
+
 # `enforcement` allows you to specify how the Codeowners Plus check should be enforced
 [enforcement]
 # see "Enforcement Options" below for more details

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -170,8 +170,10 @@ func (a *App) Run() (*OutputData, error) {
 	codeOwners.SetAuthor(author)
 
 	// Warn about unowned files
-	for _, uFile := range codeOwners.UnownedFiles() {
-		a.printWarn("WARNING: Unowned File: %s\n", uFile)
+	if !conf.SuppressUnownedWarning {
+		for _, uFile := range codeOwners.UnownedFiles() {
+			a.printWarn("WARNING: Unowned File: %s\n", uFile)
+		}
 	}
 
 	// Print file owners if verbose

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -18,6 +18,7 @@ type Config struct {
 	DetailedReviewers          bool         `toml:"detailed_reviewers"`
 	DisableSmartDismissal      bool         `toml:"disable_smart_dismissal"`
 	RequireBothBranchReviewers bool         `toml:"require_both_branch_reviewers"`
+	SuppressUnownedWarning     bool         `toml:"suppress_unowned_warning"`
 }
 
 type Enforcement struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -90,6 +90,23 @@ max_reviews = 2
 			expectedErr: false,
 		},
 		{
+			name: "config with suppress_unowned_warning enabled",
+			configContent: `
+suppress_unowned_warning = true
+`,
+			path: "testdata/",
+			expected: &Config{
+				MaxReviews:             nil,
+				MinReviews:             nil,
+				UnskippableReviewers:   []string{},
+				Ignore:                 []string{},
+				Enforcement:            &Enforcement{Approval: false, FailCheck: true},
+				HighPriorityLabels:     []string{},
+				SuppressUnownedWarning: true,
+			},
+			expectedErr: false,
+		},
+		{
 			name: "invalid toml",
 			configContent: `
 max_reviews = invalid
@@ -169,6 +186,10 @@ max_reviews = invalid
 
 				if got.RequireBothBranchReviewers != tc.expected.RequireBothBranchReviewers {
 					t.Errorf("RequireBothBranchReviewers: expected %v, got %v", tc.expected.RequireBothBranchReviewers, got.RequireBothBranchReviewers)
+				}
+
+				if got.SuppressUnownedWarning != tc.expected.SuppressUnownedWarning {
+					t.Errorf("SuppressUnownedWarning: expected %v, got %v", tc.expected.SuppressUnownedWarning, got.SuppressUnownedWarning)
 				}
 
 				if tc.expected.Enforcement != nil {


### PR DESCRIPTION
## Summary / Background

I maintain repos that don't want codeowners for all the files, this suppresses the warning that is emitted in that scenario.