### PR TITLE
ci: trigger goreleaser on tag push, create draft release

### DIFF
--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -1,8 +1,9 @@
 name: goreleaser
 
 on:
-  release:
-    types: [created]
+  push:
+    tags:
+      - 'v*'
 
 permissions: {}
 
@@ -27,6 +28,6 @@ jobs:
         uses: goreleaser/goreleaser-action@5daf1e915a5f0af01ddbcd89a43b8061ff4f1a89 # v7
         with:
           version: latest
-          args: release --clean
+          args: release --clean --config goreleaser.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/goreleaser.yml
+++ b/goreleaser.yml
@@ -58,9 +58,8 @@ checksum:
   name_template: 'checksums.txt'
 snapshot:
   version_template: "{{ .Tag }}-next"
+release:
+  draft: true
 changelog:
-  sort: asc
-  filters:
-    exclude:
-      - '^docs:'
-      - '^test:'
+  # Notes are generated manually in the GitHub UI before publishing.
+  disable: true


### PR DESCRIPTION
## Problem

Creating a release draft never triggered the goreleaser action. Two reasons:

1. The workflow triggered on the `release` event, but **draft releases do not emit `release` activity events** (`draft` isn't even a valid type; `created` doesn't fire for draft saves). `release` events only fire once a release is *published*.
2. The config file is named `goreleaser.yml` (non-standard), and the workflow ran `release --clean` without `--config`, so GoReleaser may not have auto-discovered it even if it had triggered.

## Change

- **Trigger on tag push** (`push: tags: ['v*']`) instead of the `release` event. This is GoReleaser's canonical setup.
- **Create the release as a draft** (`release.draft: true`). GoReleaser builds and uploads all artifacts to a draft; you then generate the changelog in the UI (selecting the previous tag) and publish manually. Publishing last is also required for **immutable releases**, which freeze a release's assets on publish — uploading to an already-published release would fail.
- **Disable GoReleaser's changelog** (`changelog.disable: true`) since notes are generated manually in the UI (GoReleaser's `github-native` can't pin the previous tag, which is needed for our prerelease/rc tagging).
- Pass `--config goreleaser.yml` for the non-standard filename.

## Release flow after this

1. Push a `v*` tag → workflow runs, GoReleaser creates a **draft** release with all binaries/checksums attached.
2. In the UI: **Generate release notes**, select the previous tag, review.
3. **Publish** → release is finalized (and frozen, under immutable releases) with assets intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)