### PR TITLE
feat: inline ownership blocks (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-82.7%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.8%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 
@@ -22,6 +22,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
   - [Advanced Configuration](#advanced-configuration)
     - [Enforcement Options](#enforcement-options)
   - [Quiet Mode](#quiet-mode)
+  - [Ownership Oracles](#ownership-oracles)
 - [CLI Tool](#cli-tool)
 - [Contributing](#contributing)
 - [Future Features](#future-features)
@@ -48,6 +49,7 @@ These are features missing from GitHub code owners that are supported by Codeown
   * GitHub CODEOWNERS supports only `OR` ownership rules, in contrast
 * Directory-level code ownership files to assign fine-grained code ownership
 * Supports optional reviewers (cc users/teams for non-blocking reviews)
+* Ownership oracles: external tooling can compute additional reviewer requirements from PR content (see [Ownership Oracles](#ownership-oracles))
 * Advanced global configuration (see [Advanced Configuration](#advanced-configuration))
 
 ## Getting Started
@@ -371,6 +373,53 @@ Using the `quiet` input on the action will change the behavior in a couple ways:
 
 * **Draft Pull Requests:** This is a common use case. You might want the Codeowners Plus logic to run and report a status (e.g., pending or failed) on draft PRs, but without notifying reviewers prematurely by adding comments or requesting reviews until the PR is marked "Ready for review".
 * **Custom Notification Workflows:** You might prefer to handle notifications or review requests through a different mechanism and only use Codeowners Plus for the status check enforcement.
+
+### Ownership Oracles
+
+Some ownership requirements cannot be expressed as path patterns: "changes to telemetry events need data-platform review" depends on what changed inside a file, not which file changed. Ownership oracles let external tooling compute these requirements and feed them to Codeowners Plus as data.
+
+An oracle file is JSON, written by any earlier workflow step:
+
+```json
+{
+  "rules": [
+    {
+      "files": ["src/telemetry/**"],
+      "owners": ["@your-org/data-platform"],
+      "optional": false,
+      "reason": "telemetry event schema changed in this PR"
+    }
+  ]
+}
+```
+
+* `files`: doublestar glob patterns matched against the full repo-relative paths of files changed in the PR
+* `owners`: a single OR group where any one of the listed owners satisfies the rule (same semantics as a `.codeowners` line)
+* `optional`: when `true`, owners are CC'd instead of required
+* `reason`: human-readable explanation, shown in verbose output
+
+Pass oracle files to the action with the `oracle-files` input (comma-separated):
+
+```yaml
+      - name: 'Detect telemetry changes'
+        id: detect
+        run: ./scripts/detect-telemetry-changes.sh > /tmp/telemetry-oracle.json
+
+      - name: 'Codeowners Plus'
+        uses: multimediallc/codeowners-plus@v1
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          pr: '${{ github.event.pull_request.number }}'
+          oracle-files: '/tmp/telemetry-oracle.json'
+```
+
+Oracle requirements are AND-merged with `.codeowners` requirements, the same mechanism as `require_both_branch_reviewers`: review requesting, approval tracking, smart dismissal, and the status check all apply to oracle-derived owners the same as file-derived owners.
+
+Notes:
+
+* Oracle rules can only add reviewer requirements, never remove or weaken requirements from `.codeowners` files, so a tampered oracle file can at worst request extra reviews.
+* A missing or malformed oracle file is a hard error (the check fails), since silently skipping one would drop required reviews.
+* A file matched by an oracle rule counts as owned, so it is not reported as an unowned file.
 
 ## CLI Tool
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-82.8%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.7%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
   - [Advanced Configuration](#advanced-configuration)
     - [Enforcement Options](#enforcement-options)
   - [Quiet Mode](#quiet-mode)
+  - [Inline Ownership](#inline-ownership)
   - [Ownership Oracles](#ownership-oracles)
 - [CLI Tool](#cli-tool)
 - [Contributing](#contributing)
@@ -49,6 +50,7 @@ These are features missing from GitHub code owners that are supported by Codeown
   * GitHub CODEOWNERS supports only `OR` ownership rules, in contrast
 * Directory-level code ownership files to assign fine-grained code ownership
 * Supports optional reviewers (cc users/teams for non-blocking reviews)
+* Inline ownership: comment tags that assign owners to specific regions inside a file (see [Inline Ownership](#inline-ownership))
 * Ownership oracles: external tooling can compute additional reviewer requirements from PR content (see [Ownership Oracles](#ownership-oracles))
 * Advanced global configuration (see [Advanced Configuration](#advanced-configuration))
 
@@ -256,6 +258,11 @@ self_approval_via_teams = false
 # Optional reviewers are still invited with a CC comment.
 disable_review_status_comments = false
 
+# `enable_inline_ownership` (default false) enables inline ownership blocks:
+# <CO-inline={@owner}> ... </CO-inline> comment tags in source files
+# See "Inline Ownership" below for more details
+enable_inline_ownership = false
+
 # `enforcement` allows you to specify how the Codeowners Plus check should be enforced
 [enforcement]
 # see "Enforcement Options" below for more details
@@ -374,6 +381,35 @@ Using the `quiet` input on the action will change the behavior in a couple ways:
 * **Draft Pull Requests:** This is a common use case. You might want the Codeowners Plus logic to run and report a status (e.g., pending or failed) on draft PRs, but without notifying reviewers prematurely by adding comments or requesting reviews until the PR is marked "Ready for review".
 * **Custom Notification Workflows:** You might prefer to handle notifications or review requests through a different mechanism and only use Codeowners Plus for the status check enforcement.
 
+### Inline Ownership
+
+A specific function, class, or config section sometimes needs different owners than the file around it. With `enable_inline_ownership = true` in `codeowners.toml`, you can mark a region of a source file as owned using comment tags:
+
+```go
+// <CO-inline={@alice,@security-team}>
+func ValidateToken(token string) bool {
+    ...
+}
+// </CO-inline>
+```
+
+```python
+# <CO-inline={@model-owner @devops}>
+class PaymentRecord(models.Model):
+    ...
+# </CO-inline>
+```
+
+When a PR's diff touches lines inside a block (including the tag lines), the block's owners are added as required reviewers for that file, AND-merged with the `.codeowners`-derived requirements.
+
+Semantics:
+
+* Owners inside one tag form an OR group (any listed owner satisfies it), like a `.codeowners` line, and may be separated by commas or spaces. Overlapping blocks AND together.
+* Both `//` and `#` comment prefixes are supported; tag names are case-insensitive.
+* Blocks are parsed from both the base and head revisions of each changed file, so deleting an owned region or editing the ownership tag itself still requires the owners recorded at base. Renaming a file requires approval from all of its block owners (the base revision is read under the old name).
+* Nested or unmatched tags and empty owner lists produce warnings and are skipped. An unclosed block extends to end-of-file, so a missing end tag cannot silently remove protection.
+* Inline ownership can only add reviewer requirements; it never removes or weakens `.codeowners` rules.
+
 ### Ownership Oracles
 
 Some ownership requirements cannot be expressed as path patterns: "changes to telemetry events need data-platform review" depends on what changed inside a file, not which file changed. Ownership oracles let external tooling compute these requirements and feed them to Codeowners Plus as data.
@@ -442,4 +478,4 @@ See [CONTRIBUTING.md](https://github.com/multimediallc/codeowners-plus/blob/main
 
 ## Future Features
 
-* Inline ownership comments for having owners for specific functions, classes, etc.
+* AST-aware inline ownership (attach a single ownership comment to a function/class and have the range tracked automatically)

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     description: 'The owner and repository name.  For example `octocat/Hello-World`'
     required: true
     default: '${{ github.repository }}'
+  oracle-files:
+    description: 'Comma-separated list of ownership oracle JSON files to AND-merge into .codeowners requirements'
+    required: false
+    default: ''
   verbose:
     description: 'Print debug info'
     required: false
@@ -111,6 +115,7 @@ runs:
         INPUT_GITHUB-TOKEN: ${{ inputs.github-token }}
         INPUT_PR: ${{ inputs.pr }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
+        INPUT_ORACLE-FILES: ${{ inputs.oracle-files }}
         INPUT_VERBOSE: ${{ inputs.verbose }}
         INPUT_QUIET: ${{ inputs.quiet }}
         BIN: ${{ steps.resolve.outputs.bin }}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	gh "github.com/multimediallc/codeowners-plus/internal/github"
 	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
 	f "github.com/multimediallc/codeowners-plus/pkg/functional"
+	"github.com/multimediallc/codeowners-plus/pkg/oracle"
 )
 
 // OutputData holds the data that will be written to GITHUB_OUTPUT
@@ -55,6 +56,7 @@ type Config struct {
 	RepoDir       string
 	PR            int
 	Repo          string
+	OracleFiles   []string
 	Verbose       bool
 	Quiet         bool
 	InfoBuffer    io.Writer
@@ -163,6 +165,11 @@ func (a *App) Run() (*OutputData, error) {
 			return &OutputData{}, fmt.Errorf("NewCodeOwners Error: %v", err)
 		}
 	}
+	// Merge in computed ownership from oracle files, if any
+	codeOwners, err = a.applyOracles(codeOwners, gitDiff)
+	if err != nil {
+		return &OutputData{}, err
+	}
 	a.codeowners = codeOwners
 
 	// Initialize user reviewer map
@@ -207,6 +214,37 @@ func (a *App) Run() (*OutputData, error) {
 	outputData.UpdateOutputData(success, message, stillRequired)
 
 	return outputData, nil
+}
+
+// applyOracles AND-merges computed ownership from the configured oracle
+// files into the .codeowners-derived ownership. Oracle rules can only add
+// reviewer requirements, so a missing or malformed oracle file is a hard
+// error: silently skipping one would drop required reviews.
+func (a *App) applyOracles(codeOwners codeowners.CodeOwners, gitDiff git.Diff) (codeowners.CodeOwners, error) {
+	if len(a.config.OracleFiles) == 0 {
+		return codeOwners, nil
+	}
+
+	merged := &oracle.RuleSet{}
+	for _, path := range a.config.OracleFiles {
+		ruleSet, err := oracle.Load(path)
+		if err != nil {
+			return nil, fmt.Errorf("Oracle Error: %v", err)
+		}
+		merged.Rules = append(merged.Rules, ruleSet.Rules...)
+	}
+	if len(merged.Rules) == 0 {
+		a.printDebug("Oracle files contain no rules\n")
+		return codeOwners, nil
+	}
+
+	for _, rule := range merged.Rules {
+		a.printDebug("Oracle rule: files=%v owners=%v optional=%t reason=%q\n", rule.Files, rule.Owners, rule.Optional, rule.Reason)
+	}
+
+	changedFiles := f.Map(gitDiff.AllChanges(), func(file codeowners.DiffFile) string { return file.FileName })
+	oracleOwners := merged.ToCodeOwners(changedFiles, a.config.WarningBuffer)
+	return codeowners.MergeCodeOwners(codeOwners, oracleOwners), nil
 }
 
 func (a *App) processApprovalsAndReviewers() (bool, string, []string, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -12,6 +12,7 @@ import (
 	gh "github.com/multimediallc/codeowners-plus/internal/github"
 	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
 	f "github.com/multimediallc/codeowners-plus/pkg/functional"
+	"github.com/multimediallc/codeowners-plus/pkg/inlineowners"
 	"github.com/multimediallc/codeowners-plus/pkg/oracle"
 )
 
@@ -173,6 +174,24 @@ func (a *App) Run() (*OutputData, error) {
 	if err != nil {
 		return &OutputData{}, err
 	}
+
+	// Merge in inline ownership blocks touched by the diff, if enabled.
+	// The diff is three-dot (merge-base...head), so base-side hunk line
+	// numbers are relative to the merge base, not the base branch tip;
+	// base-revision blocks must be read at the merge base or their line
+	// ranges drift whenever the base branch has advanced.
+	if conf.EnableInlineOwnership {
+		mergeBase, err := git.MergeBase(a.config.RepoDir, a.client.PR().Base.GetSHA(), a.client.PR().Head.GetSHA())
+		if err != nil {
+			return &OutputData{}, fmt.Errorf("inline ownership error: %v", err)
+		}
+		mergeBaseReader := git.NewGitRefFileReader(mergeBase, a.config.RepoDir)
+		headFileReader := git.NewGitRefFileReader(a.client.PR().Head.GetSHA(), a.config.RepoDir)
+		codeOwners, err = a.applyInlineOwnership(codeOwners, gitDiff, mergeBaseReader, headFileReader)
+		if err != nil {
+			return &OutputData{}, err
+		}
+	}
 	a.codeowners = codeOwners
 
 	// Initialize user reviewer map
@@ -248,6 +267,33 @@ func (a *App) applyOracles(codeOwners codeowners.CodeOwners, gitDiff git.Diff) (
 	changedFiles := f.Map(gitDiff.AllChanges(), func(file codeowners.DiffFile) string { return file.FileName })
 	oracleOwners := merged.ToCodeOwners(changedFiles, a.config.WarningBuffer)
 	return codeowners.MergeCodeOwners(codeOwners, oracleOwners), nil
+}
+
+// applyInlineOwnership AND-merges ownership from inline <CO-inline> blocks
+// touched by the diff, via the same MergeCodeOwners path as oracle files
+// and require_both_branch_reviewers. A failure to read a file is a hard
+// error, matching the fail-closed handling of oracle files.
+func (a *App) applyInlineOwnership(
+	codeOwners codeowners.CodeOwners,
+	gitDiff git.Diff,
+	baseFileReader codeowners.FileReader,
+	headFileReader codeowners.FileReader,
+) (codeowners.CodeOwners, error) {
+	requirements, err := inlineowners.Requirements(gitDiff.AllChanges(), baseFileReader, headFileReader, a.config.WarningBuffer)
+	if err != nil {
+		return nil, fmt.Errorf("inline ownership error: %v", err)
+	}
+	if len(requirements) == 0 {
+		a.printDebug("No inline ownership blocks touched by this diff\n")
+		return codeOwners, nil
+	}
+	rgm := codeowners.NewReviewerGroupMemo()
+	required := make(map[string]codeowners.ReviewerGroups)
+	for _, requirement := range requirements {
+		a.printDebug("Inline ownership: file=%s owners=%v reason=%q\n", requirement.File, requirement.Owners, requirement.Reason)
+		required[requirement.File] = append(required[requirement.File], rgm.ToReviewerGroup(requirement.Owners...))
+	}
+	return codeowners.MergeCodeOwners(codeOwners, codeowners.NewFromFileOwners(required, nil)), nil
 }
 
 func (a *App) processApprovalsAndReviewers() (bool, string, []string, error) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -232,7 +232,7 @@ func (a *App) applyOracles(codeOwners codeowners.CodeOwners, gitDiff git.Diff) (
 	for _, path := range a.config.OracleFiles {
 		ruleSet, err := oracle.Load(path)
 		if err != nil {
-			return nil, fmt.Errorf("Oracle Error: %v", err)
+			return nil, fmt.Errorf("oracle error: %v", err)
 		}
 		merged.Rules = append(merged.Rules, ruleSet.Rules...)
 	}

--- a/internal/app/inline_e2e_test.go
+++ b/internal/app/inline_e2e_test.go
@@ -1,0 +1,247 @@
+package app
+
+// End-to-end tests for inline ownership: build a real git repository with
+// inline-tagged source files and run the real diff parser, git-ref file
+// readers, and applyInlineOwnership over each change shape.
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/multimediallc/codeowners-plus/internal/git"
+	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
+	"github.com/multimediallc/codeowners-plus/pkg/inlineowners"
+)
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=test", "GIT_AUTHOR_EMAIL=test@example.com",
+		"GIT_COMMITTER_NAME=test", "GIT_COMMITTER_EMAIL=test@example.com",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeRepoFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func inlineOwnersByFile(requirements []inlineowners.Requirement) map[string][]string {
+	result := make(map[string][]string)
+	for _, requirement := range requirements {
+		for _, owner := range requirement.Owners {
+			if !slices.Contains(result[requirement.File], owner) {
+				result[requirement.File] = append(result[requirement.File], owner)
+			}
+		}
+	}
+	return result
+}
+
+const padding = "pad1\npad2\npad3\npad4\npad5\npad6\n"
+
+func TestInlineOwnershipE2E(t *testing.T) {
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-b", "main")
+
+	// Base revision
+	writeRepoFile(t, dir, "frontend/a.ts", padding+
+		"// <CO-inline={@frontend-inline}>\nconst a = 1;\n// </CO-inline>\n"+padding)
+	writeRepoFile(t, dir, "frontend/b.ts",
+		"// <CO-inline={@frontend-inline}>\nconst b = 1;\n// </CO-inline>\n")
+	writeRepoFile(t, dir, "models.py",
+		"# <CO-inline={@model-owner,@devops}>\nfield_one = 1\nfield_two = 2\n# </CO-inline>\n")
+	writeRepoFile(t, dir, "deleted.go",
+		"// <CO-inline={@keeper}>\nvar precious = true\n// </CO-inline>\n")
+	writeRepoFile(t, dir, "appended.ts",
+		"// <CO-inline={@append-guard}>\nconst guarded = 1;\n// </CO-inline>\n")
+	writeRepoFile(t, dir, "renamed_src.ts", padding+padding+
+		"// <CO-inline={@rename-guard}>\nconst secret = 1;\n// </CO-inline>\n"+padding+padding)
+	writeRepoFile(t, dir, "plain.ts", padding+"const plain = 1;\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "base")
+	baseSHA := gitRun(t, dir, "rev-parse", "HEAD")
+
+	// Head revision
+	writeRepoFile(t, dir, "frontend/a.ts", padding+
+		"// <CO-inline={@frontend-inline}>\nconst a = 1;\nconst added = 2;\n// </CO-inline>\n"+padding)
+	writeRepoFile(t, dir, "frontend/b.ts",
+		"// <CO-inline={@attacker}>\nconst b = 1;\n// </CO-inline>\n")
+	writeRepoFile(t, dir, "models.py",
+		"# <CO-inline={@model-owner,@devops}>\nfield_one = 1\n# </CO-inline>\n")
+	if err := os.Remove(filepath.Join(dir, "deleted.go")); err != nil {
+		t.Fatal(err)
+	}
+	// Append a line AFTER the block's end tag: the insertion produces a
+	// zero-length base-side hunk, which must not count as touching the block.
+	writeRepoFile(t, dir, "appended.ts",
+		"// <CO-inline={@append-guard}>\nconst guarded = 1;\n// </CO-inline>\nconst afterBlock = 2;\n")
+	// Rename with no content change: base blocks still require approval.
+	gitRun(t, dir, "mv", "renamed_src.ts", "renamed_dst.ts")
+	writeRepoFile(t, dir, "plain.ts", padding+"const plainChanged = 2;\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "head")
+	headSHA := gitRun(t, dir, "rev-parse", "HEAD")
+
+	gitDiff, err := git.NewDiff(git.DiffContext{Base: baseSHA, Head: headSHA, Dir: dir})
+	if err != nil {
+		t.Fatalf("NewDiff error: %v", err)
+	}
+	baseReader := git.NewGitRefFileReader(baseSHA, dir)
+	headReader := git.NewGitRefFileReader(headSHA, dir)
+
+	warn := &bytes.Buffer{}
+	requirements, err := inlineowners.Requirements(gitDiff.AllChanges(), baseReader, headReader, warn)
+	if err != nil {
+		t.Fatalf("Requirements error: %v", err)
+	}
+
+	owners := inlineOwnersByFile(requirements)
+	expected := map[string][]string{
+		// edit inside a block requires the block owner
+		"frontend/a.ts": {"@frontend-inline"},
+		// tampering with the tag requires the base owner AND the new owner
+		"frontend/b.ts": {"@frontend-inline", "@attacker"},
+		// deleting a line inside a block requires the block owners
+		"models.py": {"@model-owner", "@devops"},
+		// deleting a whole owned file requires the owner recorded at base
+		"deleted.go": {"@keeper"},
+		// a pure rename requires the owners of all base blocks
+		"renamed_dst.ts": {"@rename-guard"},
+	}
+	for file, expectedOwners := range expected {
+		for _, owner := range expectedOwners {
+			if !slices.Contains(owners[file], owner) {
+				t.Errorf("expected %s to require %s, got %v", file, owner, owners[file])
+			}
+		}
+	}
+	// appended.ts (change after the block) and plain.ts require nothing
+	for _, file := range []string{"appended.ts", "plain.ts"} {
+		if len(owners[file]) != 0 {
+			t.Errorf("expected no inline owners for %s, got %v", file, owners[file])
+		}
+	}
+
+	// Push the requirements through the app merge path and confirm they
+	// compose with .codeowners-derived ownership.
+	rgm := codeowners.NewReviewerGroupMemo()
+	base := codeowners.NewFromFileOwners(map[string]codeowners.ReviewerGroups{
+		"frontend/a.ts": {rgm.ToReviewerGroup("@frontend-team")},
+	}, nil)
+	app := oracleTestApp(nil)
+	merged, err := app.applyInlineOwnership(base, gitDiff, baseReader, headReader)
+	if err != nil {
+		t.Fatalf("applyInlineOwnership error: %v", err)
+	}
+
+	aOwners := codeowners.OriginalStrings(merged.FileRequired()["frontend/a.ts"].Flatten())
+	if !slices.Contains(aOwners, "@frontend-team") || !slices.Contains(aOwners, "@frontend-inline") {
+		t.Errorf("expected merged owners to include .codeowners and inline owners, got %v", aOwners)
+	}
+	bOwners := codeowners.OriginalStrings(merged.FileRequired()["frontend/b.ts"].Flatten())
+	if !slices.Contains(bOwners, "@frontend-inline") || !slices.Contains(bOwners, "@attacker") {
+		t.Errorf("expected merged owners for tampered tag, got %v", bOwners)
+	}
+}
+
+func TestInlineOwnershipAdvancedBaseBranch(t *testing.T) {
+	// Diffs are three-dot (merge-base...head), so base-side hunk line
+	// numbers are relative to the merge base. When the base branch
+	// advances after the PR branches (shifting the protected block's
+	// lines at the base tip), blocks must be read at the merge base or
+	// the overlap check misses them.
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-b", "main")
+
+	writeRepoFile(t, dir, "guarded.ts", padding+
+		"// <CO-inline={@guard}>\nconst guarded = 1;\n// </CO-inline>\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "base")
+	branchPoint := gitRun(t, dir, "rev-parse", "HEAD")
+
+	// PR branch: edit inside the block
+	gitRun(t, dir, "checkout", "-b", "feature")
+	writeRepoFile(t, dir, "guarded.ts", padding+
+		"// <CO-inline={@guard}>\nconst guarded = 2;\n// </CO-inline>\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "head")
+	headSHA := gitRun(t, dir, "rev-parse", "HEAD")
+
+	// Base branch advances: prepend lines, shifting the block down
+	gitRun(t, dir, "checkout", "main")
+	writeRepoFile(t, dir, "guarded.ts", padding+padding+padding+
+		"// <CO-inline={@guard}>\nconst guarded = 1;\n// </CO-inline>\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "base advances")
+	baseTipSHA := gitRun(t, dir, "rev-parse", "HEAD")
+
+	mergeBase, err := git.MergeBase(dir, baseTipSHA, headSHA)
+	if err != nil {
+		t.Fatalf("MergeBase error: %v", err)
+	}
+	if mergeBase != branchPoint {
+		t.Fatalf("expected merge base %s, got %s", branchPoint, mergeBase)
+	}
+
+	gitDiff, err := git.NewDiff(git.DiffContext{Base: baseTipSHA, Head: headSHA, Dir: dir})
+	if err != nil {
+		t.Fatalf("NewDiff error: %v", err)
+	}
+	headReader := git.NewGitRefFileReader(headSHA, dir)
+
+	// Reading base blocks at the merge base finds the touched block.
+	requirements, err := inlineowners.Requirements(gitDiff.AllChanges(), git.NewGitRefFileReader(mergeBase, dir), headReader, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("Requirements error: %v", err)
+	}
+	if !slices.Contains(inlineOwnersByFile(requirements)["guarded.ts"], "@guard") {
+		t.Errorf("expected @guard requirement with merge-base reader, got %+v", requirements)
+	}
+}
+
+func TestApplyInlineOwnershipNoBlocks(t *testing.T) {
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-b", "main")
+	writeRepoFile(t, dir, "plain.ts", "const plain = 1;\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "base")
+	baseSHA := gitRun(t, dir, "rev-parse", "HEAD")
+	writeRepoFile(t, dir, "plain.ts", "const plainChanged = 2;\n")
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-m", "head")
+	headSHA := gitRun(t, dir, "rev-parse", "HEAD")
+
+	gitDiff, err := git.NewDiff(git.DiffContext{Base: baseSHA, Head: headSHA, Dir: dir})
+	if err != nil {
+		t.Fatalf("NewDiff error: %v", err)
+	}
+
+	base := baseCodeOwnersForOracleTest()
+	app := oracleTestApp(nil)
+	merged, err := app.applyInlineOwnership(base, gitDiff, git.NewGitRefFileReader(baseSHA, dir), git.NewGitRefFileReader(headSHA, dir))
+	if err != nil {
+		t.Fatalf("applyInlineOwnership error: %v", err)
+	}
+	if merged != base {
+		t.Error("expected base CodeOwners returned unchanged when no inline blocks are touched")
+	}
+}

--- a/internal/app/oracle_test.go
+++ b/internal/app/oracle_test.go
@@ -1,0 +1,177 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
+)
+
+// NewFromFileOwners is covered here (rather than pkg/codeowners) because
+// its consumers are the oracle and inline-ownership merge paths.
+func TestNewFromFileOwners(t *testing.T) {
+	rgm := codeowners.NewReviewerGroupMemo()
+	co := codeowners.NewFromFileOwners(
+		map[string]codeowners.ReviewerGroups{
+			"both.go":     {rgm.ToReviewerGroup("@required")},
+			"required.go": {rgm.ToReviewerGroup("@required"), rgm.ToReviewerGroup("@required")},
+		},
+		map[string]codeowners.ReviewerGroups{
+			"both.go":     {rgm.ToReviewerGroup("@optional")},
+			"optional.go": {rgm.ToReviewerGroup("@optional")},
+		},
+	)
+
+	if len(co.FileRequired()["both.go"]) != 1 || len(co.FileOptional()["both.go"]) != 1 {
+		t.Errorf("expected both.go to carry one required and one optional group, got %+v / %+v",
+			co.FileRequired()["both.go"], co.FileOptional()["both.go"])
+	}
+	if len(co.FileRequired()["required.go"]) != 1 {
+		t.Errorf("expected duplicate groups to be deduplicated, got %d", len(co.FileRequired()["required.go"]))
+	}
+	if _, ok := co.FileRequired()["optional.go"]; ok {
+		t.Error("optional-only file should have no required reviewers")
+	}
+	if len(co.UnownedFiles()) != 0 {
+		t.Errorf("expected no unowned files, got %v", co.UnownedFiles())
+	}
+}
+
+func writeOracleFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "oracle.json")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func oracleTestApp(oracleFiles []string) *App {
+	return &App{
+		config: &Config{
+			OracleFiles:   oracleFiles,
+			InfoBuffer:    &bytes.Buffer{},
+			WarningBuffer: &bytes.Buffer{},
+		},
+	}
+}
+
+func baseCodeOwnersForOracleTest() codeowners.CodeOwners {
+	rgm := codeowners.NewReviewerGroupMemo()
+	return codeowners.NewFromFileOwners(map[string]codeowners.ReviewerGroups{
+		"src/telemetry/events.ts": {rgm.ToReviewerGroup("@org/frontend")},
+	}, nil)
+}
+
+func TestApplyOraclesNoFiles(t *testing.T) {
+	app := oracleTestApp(nil)
+	base := baseCodeOwnersForOracleTest()
+	result, err := app.applyOracles(base, mockGitDiff{changes: []string{"src/telemetry/events.ts"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != base {
+		t.Error("expected base CodeOwners to be returned unchanged when no oracle files are configured")
+	}
+}
+
+func TestApplyOraclesMergesRequirements(t *testing.T) {
+	path := writeOracleFile(t, `{"rules": [
+		{"files": ["src/telemetry/**"], "owners": ["@org/data-platform"], "reason": "NR event change"}
+	]}`)
+	app := oracleTestApp([]string{path})
+	base := baseCodeOwnersForOracleTest()
+
+	result, err := app.applyOracles(base, mockGitDiff{changes: []string{"src/telemetry/events.ts", "other.go"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	groups := result.FileRequired()["src/telemetry/events.ts"]
+	names := codeowners.OriginalStrings(groups.Flatten())
+	if !slices.Contains(names, "@org/frontend") || !slices.Contains(names, "@org/data-platform") {
+		t.Errorf("expected both base and oracle owners, got %v", names)
+	}
+	if len(groups) != 2 {
+		t.Errorf("expected 2 AND groups, got %d", len(groups))
+	}
+}
+
+func TestApplyOraclesMissingFile(t *testing.T) {
+	app := oracleTestApp([]string{"/nonexistent/oracle.json"})
+	_, err := app.applyOracles(baseCodeOwnersForOracleTest(), mockGitDiff{changes: []string{"a.go"}})
+	if err == nil || !strings.Contains(err.Error(), "Oracle Error") {
+		t.Errorf("expected hard error for missing oracle file, got %v", err)
+	}
+}
+
+func TestApplyOraclesMultipleFiles(t *testing.T) {
+	pathA := writeOracleFile(t, `{"rules": [
+		{"files": ["src/telemetry/**"], "owners": ["@org/data-platform"]}
+	]}`)
+	pathB := writeOracleFile(t, `{"rules": [
+		{"files": ["src/**"], "owners": ["@org/security"]}
+	]}`)
+	app := oracleTestApp([]string{pathA, pathB})
+	base := baseCodeOwnersForOracleTest()
+
+	result, err := app.applyOracles(base, mockGitDiff{changes: []string{"src/telemetry/events.ts"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	groups := result.FileRequired()["src/telemetry/events.ts"]
+	names := codeowners.OriginalStrings(groups.Flatten())
+	for _, expected := range []string{"@org/frontend", "@org/data-platform", "@org/security"} {
+		if !slices.Contains(names, expected) {
+			t.Errorf("expected owner %s from merged oracle files, got %v", expected, names)
+		}
+	}
+	if len(groups) != 3 {
+		t.Errorf("expected 3 AND groups (base + one per oracle file), got %d", len(groups))
+	}
+}
+
+func TestApplyOraclesUnownedFileBecomesOwned(t *testing.T) {
+	// A file .codeowners reports as unowned stops being reported once an
+	// oracle rule matches it (documented behavior).
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package a"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	diff := mockGitDiff{changes: []string{"a.go"}}
+	base, err := codeowners.New(dir, diff.AllChanges(), nil, &bytes.Buffer{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(base.UnownedFiles()) != 1 {
+		t.Fatalf("expected a.go to start unowned, got %v", base.UnownedFiles())
+	}
+
+	path := writeOracleFile(t, `{"rules": [{"files": ["a.go"], "owners": ["@org/adopters"]}]}`)
+	app := oracleTestApp([]string{path})
+	result, err := app.applyOracles(base, diff)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(result.UnownedFiles()) != 0 {
+		t.Errorf("oracle-matched file should count as owned, got unowned: %v", result.UnownedFiles())
+	}
+}
+
+func TestApplyOraclesEmptyRules(t *testing.T) {
+	path := writeOracleFile(t, `{"rules": []}`)
+	app := oracleTestApp([]string{path})
+	base := baseCodeOwnersForOracleTest()
+	result, err := app.applyOracles(base, mockGitDiff{changes: []string{"a.go"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != base {
+		t.Error("expected base CodeOwners to be returned unchanged for empty oracle rules")
+	}
+}

--- a/internal/app/oracle_test.go
+++ b/internal/app/oracle_test.go
@@ -104,7 +104,7 @@ func TestApplyOraclesMergesRequirements(t *testing.T) {
 func TestApplyOraclesMissingFile(t *testing.T) {
 	app := oracleTestApp([]string{"/nonexistent/oracle.json"})
 	_, err := app.applyOracles(baseCodeOwnersForOracleTest(), mockGitDiff{changes: []string{"a.go"}})
-	if err == nil || !strings.Contains(err.Error(), "Oracle Error") {
+	if err == nil || !strings.Contains(err.Error(), "oracle error") {
 		t.Errorf("expected hard error for missing oracle file, got %v", err)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	AllowSelfApproval           bool         `toml:"allow_self_approval"`
 	SelfApprovalViaTeams        bool         `toml:"self_approval_via_teams"`
 	DisableReviewStatusComments bool         `toml:"disable_review_status_comments"`
+	EnableInlineOwnership       bool         `toml:"enable_inline_ownership"`
 }
 
 type Enforcement struct {
@@ -52,6 +53,7 @@ func ReadConfig(path string, fileReader codeowners.FileReader) (*Config, error) 
 		DisableSmartDismissal:       false,
 		RequireBothBranchReviewers:  false,
 		DisableReviewStatusComments: false,
+		EnableInlineOwnership:       false,
 	}
 
 	// Use filesystem reader if none provided

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -126,6 +126,23 @@ allow_self_approval = true
 			expectedErr: false,
 		},
 		{
+			name: "config with enable_inline_ownership enabled",
+			configContent: `
+enable_inline_ownership = true
+`,
+			path: "testdata/",
+			expected: &Config{
+				MaxReviews:            nil,
+				MinReviews:            nil,
+				UnskippableReviewers:  []string{},
+				Ignore:                []string{},
+				Enforcement:           &Enforcement{Approval: false, FailCheck: true},
+				HighPriorityLabels:    []string{},
+				EnableInlineOwnership: true,
+			},
+			expectedErr: false,
+		},
+		{
 			name: "invalid toml",
 			configContent: `
 max_reviews = invalid
@@ -205,6 +222,10 @@ max_reviews = invalid
 
 				if got.RequireBothBranchReviewers != tc.expected.RequireBothBranchReviewers {
 					t.Errorf("RequireBothBranchReviewers: expected %v, got %v", tc.expected.RequireBothBranchReviewers, got.RequireBothBranchReviewers)
+				}
+
+				if got.EnableInlineOwnership != tc.expected.EnableInlineOwnership {
+					t.Errorf("EnableInlineOwnership: expected %v, got %v", tc.expected.EnableInlineOwnership, got.EnableInlineOwnership)
 				}
 
 				if got.SuppressUnownedWarning != tc.expected.SuppressUnownedWarning {

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -127,6 +127,15 @@ func diffToFilename(d *diff.FileDiff) string {
 	return filenameFromExtendedHeader(d.Extended)
 }
 
+// diffToBaseFilename returns the file's name in the base revision, or ""
+// when the diff carries no usable original name (e.g. added files).
+func diffToBaseFilename(d *diff.FileDiff) string {
+	if len(d.OrigName) > 2 && d.OrigName != "/dev/null" {
+		return d.OrigName[2:]
+	}
+	return ""
+}
+
 func filenameFromExtendedHeader(headers []string) string {
 	for _, h := range headers {
 		rest, ok := strings.CutPrefix(h, "diff --git ")
@@ -152,9 +161,15 @@ func toDiffFiles(fileDiffs []*diff.FileDiff) ([]codeowners.DiffFile, error) {
 	for _, d := range fileDiffs {
 		fileName := diffToFilename(d)
 
+		baseFileName := diffToBaseFilename(d)
+		if baseFileName == fileName {
+			baseFileName = ""
+		}
 		newDiffFile := codeowners.DiffFile{
-			FileName: fileName,
-			Hunks:    make([]codeowners.HunkRange, 0, len(d.Hunks)),
+			FileName:     fileName,
+			BaseFileName: baseFileName,
+			Hunks:        make([]codeowners.HunkRange, 0, len(d.Hunks)),
+			BaseHunks:    make([]codeowners.HunkRange, 0, len(d.Hunks)),
 		}
 		for _, hunk := range d.Hunks {
 			newHunkRange := codeowners.HunkRange{
@@ -162,6 +177,11 @@ func toDiffFiles(fileDiffs []*diff.FileDiff) ([]codeowners.DiffFile, error) {
 				End:   int(hunk.NewStartLine + hunk.NewLines - 1),
 			}
 			newDiffFile.Hunks = append(newDiffFile.Hunks, newHunkRange)
+			baseHunkRange := codeowners.HunkRange{
+				Start: int(hunk.OrigStartLine),
+				End:   int(hunk.OrigStartLine + hunk.OrigLines - 1),
+			}
+			newDiffFile.BaseHunks = append(newDiffFile.BaseHunks, baseHunkRange)
 		}
 		diffFiles = append(diffFiles, newDiffFile)
 	}
@@ -185,9 +205,15 @@ func changesSince(context changesSinceContext) ([]codeowners.DiffFile, error) {
 	for _, d := range context.newerDiff {
 		fileName := diffToFilename(d)
 
+		baseFileName := diffToBaseFilename(d)
+		if baseFileName == fileName {
+			baseFileName = ""
+		}
 		newDiffFile := codeowners.DiffFile{
-			FileName: fileName,
-			Hunks:    make([]codeowners.HunkRange, 0, len(d.Hunks)),
+			FileName:     fileName,
+			BaseFileName: baseFileName,
+			Hunks:        make([]codeowners.HunkRange, 0, len(d.Hunks)),
+			BaseHunks:    make([]codeowners.HunkRange, 0, len(d.Hunks)),
 		}
 		for _, hunk := range d.Hunks {
 			if !oldHunkHashes[hunkHash(hunk)] {
@@ -196,6 +222,11 @@ func changesSince(context changesSinceContext) ([]codeowners.DiffFile, error) {
 					End:   int(hunk.NewStartLine + hunk.NewLines - 1),
 				}
 				newDiffFile.Hunks = append(newDiffFile.Hunks, newHunkRange)
+				baseHunkRange := codeowners.HunkRange{
+					Start: int(hunk.OrigStartLine),
+					End:   int(hunk.OrigStartLine + hunk.OrigLines - 1),
+				}
+				newDiffFile.BaseHunks = append(newDiffFile.BaseHunks, baseHunkRange)
 			}
 		}
 		// Binary files have no hunks; staleness is intentionally not tracked
@@ -217,16 +248,25 @@ func getGitDiff(data DiffContext, executor gitCommandExecutor) ([]*diff.FileDiff
 		return nil, err
 	}
 	gitDiff = slices.DeleteFunc(gitDiff, func(d *diff.FileDiff) bool {
-		fileName := diffToFilename(d)
-
-		for _, dir := range data.IgnoreDirs {
-			if strings.HasPrefix(fileName, dir) {
-				return true
-			}
-		}
-		return false
+		// A file is dropped only when BOTH its old and new paths are
+		// ignored; otherwise renaming a file into an ignored directory
+		// would hide it from ownership checks.
+		return isIgnored(diffToFilename(d), data.IgnoreDirs) &&
+			isIgnored(diffToBaseFilename(d), data.IgnoreDirs)
 	})
 	return gitDiff, nil
+}
+
+func isIgnored(fileName string, ignoreDirs []string) bool {
+	if fileName == "" {
+		return true
+	}
+	for _, dir := range ignoreDirs {
+		if strings.HasPrefix(fileName, dir) {
+			return true
+		}
+	}
+	return false
 }
 
 func hunkHash(hunk *diff.Hunk) [32]byte {

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -806,3 +806,96 @@ func TestDiffOfDiffs(t *testing.T) {
 		}
 	}
 }
+
+func TestToDiffFilesBaseFields(t *testing.T) {
+	fileDiffs := []*diff.FileDiff{
+		{
+			OrigName: "a/old.go",
+			NewName:  "b/new.go",
+			Hunks: []*diff.Hunk{
+				{
+					OrigStartLine: 5,
+					OrigLines:     2,
+					NewStartLine:  10,
+					NewLines:      3,
+				},
+			},
+		},
+		{
+			OrigName: "a/same.go",
+			NewName:  "b/same.go",
+			Hunks: []*diff.Hunk{
+				{
+					OrigStartLine: 3,
+					OrigLines:     0,
+					NewStartLine:  4,
+					NewLines:      1,
+				},
+			},
+		},
+	}
+
+	result, err := toDiffFiles(fileDiffs)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	renamed := result[0]
+	if renamed.FileName != "new.go" || renamed.BaseFileName != "old.go" || renamed.BaseName() != "old.go" {
+		t.Errorf("expected rename tracked as new.go/old.go, got %q/%q", renamed.FileName, renamed.BaseFileName)
+	}
+	expectedBase := codeowners.HunkRange{Start: 5, End: 6}
+	if len(renamed.BaseHunks) != 1 || renamed.BaseHunks[0] != expectedBase {
+		t.Errorf("expected base hunks [%+v], got %+v", expectedBase, renamed.BaseHunks)
+	}
+
+	same := result[1]
+	if same.BaseFileName != "" || same.BaseName() != "same.go" {
+		t.Errorf("expected no base name for unrenamed file, got %q", same.BaseFileName)
+	}
+	// A pure insertion has a zero-length base hunk (End < Start)
+	expectedEmpty := codeowners.HunkRange{Start: 3, End: 2}
+	if len(same.BaseHunks) != 1 || same.BaseHunks[0] != expectedEmpty {
+		t.Errorf("expected empty base hunk %+v, got %+v", expectedEmpty, same.BaseHunks)
+	}
+}
+
+const renameIntoIgnoredDiff = `diff --git a/src/secure.go b/test_project/secure.go
+similarity index 90%
+rename from src/secure.go
+rename to test_project/secure.go
+index abc..def 100644
+--- a/src/secure.go
++++ b/test_project/secure.go
+@@ -1 +1 @@
+-var token = "old"
++var token = "new"
+diff --git a/test_project/existing.go b/test_project/existing.go
+index ghi..jkl 100644
+--- a/test_project/existing.go
++++ b/test_project/existing.go
+@@ -1 +1 @@
+-var a = 1
++var a = 2`
+
+func TestIgnoreDirsKeepsRenamesOutOfIgnored(t *testing.T) {
+	executor := NewMockGitExecutor(renameIntoIgnoredDiff, nil)
+	gitDiff, err := NewDiffWithExecutor(DiffContext{
+		Base:       "base",
+		Head:       "head",
+		IgnoreDirs: []string{"test_project"},
+	}, executor)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	changes := gitDiff.AllChanges()
+	if len(changes) != 1 {
+		t.Fatalf("expected 1 change (rename kept, ignored-only file dropped), got %+v", changes)
+	}
+	// A file renamed INTO an ignored directory stays visible, since its
+	// old path is still owned.
+	if changes[0].FileName != "test_project/secure.go" || changes[0].BaseName() != "src/secure.go" {
+		t.Errorf("expected the rename out of src/ to be kept, got %+v", changes[0])
+	}
+}

--- a/internal/git/merge_base.go
+++ b/internal/git/merge_base.go
@@ -1,0 +1,20 @@
+package git
+
+import (
+	"fmt"
+	"strings"
+)
+
+// MergeBase returns the merge base of two refs. Diffs are produced with
+// three-dot syntax (base...head), so hunk line numbers are relative to
+// the merge base, not the base branch tip; consumers that map hunk
+// coordinates onto base-revision file content must read files at this
+// ref.
+func MergeBase(dir string, base string, head string) (string, error) {
+	executor := newRealGitExecutor(dir)
+	output, err := executor.execute("git", "merge-base", base, head)
+	if err != nil {
+		return "", fmt.Errorf("git merge-base %s %s: %s\n%s", base, head, err, output)
+	}
+	return strings.TrimSpace(string(output)), nil
+}

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/multimediallc/codeowners-plus/internal/app"
@@ -15,22 +16,24 @@ import (
 
 // Flags holds the command line flags
 type Flags struct {
-	Token   *string
-	RepoDir *string
-	PR      *int
-	Repo    *string
-	Verbose *bool
-	Quiet   *bool
+	Token       *string
+	RepoDir     *string
+	PR          *int
+	Repo        *string
+	OracleFiles *string
+	Verbose     *bool
+	Quiet       *bool
 }
 
 var (
 	flags = &Flags{
-		Token:   flag.String("token", getEnv("INPUT_GITHUB-TOKEN", ""), "GitHub authentication token"),
-		RepoDir: flag.String("dir", getEnv("GITHUB_WORKSPACE", "/"), "Path to local Git repo"),
-		PR:      flag.Int("pr", ignoreError(strconv.Atoi(getEnv("INPUT_PR", ""))), "Pull Request number"),
-		Repo:    flag.String("repo", getEnv("INPUT_REPOSITORY", ""), "GitHub repo name"),
-		Verbose: flag.Bool("v", ignoreError(strconv.ParseBool(getEnv("INPUT_VERBOSE", "0"))), "Verbose output"),
-		Quiet:   flag.Bool("quiet", ignoreError(strconv.ParseBool(getEnv("INPUT_QUIET", "0"))), "Disable PR comments and review requests"),
+		Token:       flag.String("token", getEnv("INPUT_GITHUB-TOKEN", ""), "GitHub authentication token"),
+		RepoDir:     flag.String("dir", getEnv("GITHUB_WORKSPACE", "/"), "Path to local Git repo"),
+		PR:          flag.Int("pr", ignoreError(strconv.Atoi(getEnv("INPUT_PR", ""))), "Pull Request number"),
+		Repo:        flag.String("repo", getEnv("INPUT_REPOSITORY", ""), "GitHub repo name"),
+		OracleFiles: flag.String("oracle-files", getEnv("INPUT_ORACLE-FILES", ""), "Comma-separated list of ownership oracle JSON files"),
+		Verbose:     flag.Bool("v", ignoreError(strconv.ParseBool(getEnv("INPUT_VERBOSE", "0"))), "Verbose output"),
+		Quiet:       flag.Bool("quiet", ignoreError(strconv.ParseBool(getEnv("INPUT_QUIET", "0"))), "Disable PR comments and review requests"),
 	}
 	WarningBuffer = bytes.NewBuffer([]byte{})
 	InfoBuffer    = bytes.NewBuffer([]byte{})
@@ -71,6 +74,19 @@ func getEnv(key, fallback string) string {
 
 func ignoreError[V any, E error](res V, _ E) V {
 	return res
+}
+
+// splitOracleFiles parses the comma-separated oracle-files flag, dropping
+// empty entries so an unset input yields no oracle files.
+func splitOracleFiles(value string) []string {
+	parts := strings.Split(value, ",")
+	files := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if trimmed := strings.TrimSpace(part); trimmed != "" {
+			files = append(files, trimmed)
+		}
+	}
+	return files
 }
 
 func outputAndExit(w io.Writer, shouldFail bool, message string) {
@@ -130,6 +146,7 @@ func main() {
 		RepoDir:       *flags.RepoDir,
 		PR:            *flags.PR,
 		Repo:          *flags.Repo,
+		OracleFiles:   splitOracleFiles(*flags.OracleFiles),
 		Verbose:       *flags.Verbose,
 		Quiet:         *flags.Quiet,
 		InfoBuffer:    InfoBuffer,

--- a/main_test.go
+++ b/main_test.go
@@ -14,11 +14,12 @@ import (
 func init() {
 	// Initialize test flags with default values
 	flags = &Flags{
-		Token:   new(string),
-		RepoDir: new(string),
-		PR:      new(int),
-		Repo:    new(string),
-		Verbose: new(bool),
+		Token:       new(string),
+		RepoDir:     new(string),
+		PR:          new(int),
+		Repo:        new(string),
+		OracleFiles: new(string),
+		Verbose:     new(bool),
 	}
 	*flags.Token = "test-token"
 	*flags.RepoDir = "/test/dir"
@@ -96,6 +97,33 @@ func TestIgnoreError(t *testing.T) {
 			got := ignoreError(tc.value, tc.err)
 			if got != tc.expected {
 				t.Errorf("expected %d, got %d", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestSplitOracleFiles(t *testing.T) {
+	tt := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{name: "empty input", input: "", expected: []string{}},
+		{name: "single file", input: "a.json", expected: []string{"a.json"}},
+		{name: "multiple files", input: "a.json,b.json", expected: []string{"a.json", "b.json"}},
+		{name: "whitespace trimmed", input: " a.json , b.json ", expected: []string{"a.json", "b.json"}},
+		{name: "empty entries dropped", input: ",a.json,,", expected: []string{"a.json"}},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			result := splitOracleFiles(tc.input)
+			if len(result) != len(tc.expected) {
+				t.Fatalf("expected %v, got %v", tc.expected, result)
+			}
+			for i := range result {
+				if result[i] != tc.expected[i] {
+					t.Errorf("expected %v, got %v", tc.expected, result)
+				}
 			}
 		})
 	}

--- a/pkg/codeowners/codeowners.go
+++ b/pkg/codeowners/codeowners.go
@@ -55,6 +55,35 @@ func New(root string, files []DiffFile, fileReader FileReader, warningWriter io.
 	return ownersMap, err
 }
 
+// NewFromFileOwners creates a CodeOwners directly from file-to-reviewers
+// maps, for ownership computed outside the .codeowners file tree (oracle
+// rules, inline ownership blocks). Files absent from both maps are not
+// tracked, so merging the result via MergeCodeOwners treats every file it
+// names as owned and leaves all other files' unowned status to the other
+// side of the merge.
+func NewFromFileOwners(required map[string]ReviewerGroups, optional map[string]ReviewerGroups) CodeOwners {
+	fileToOwner := make(map[string]fileOwners)
+	for file, groups := range required {
+		fileToOwner[file] = fileOwners{
+			requiredReviewers: f.RemoveDuplicates(groups),
+			optionalReviewers: make(ReviewerGroups, 0),
+		}
+	}
+	for file, groups := range optional {
+		owners, ok := fileToOwner[file]
+		if !ok {
+			owners = *newFileOwners()
+		}
+		owners.optionalReviewers = f.RemoveDuplicates(groups)
+		fileToOwner[file] = owners
+	}
+	return &ownersMap{
+		fileToOwner:     fileToOwner,
+		nameReviewerMap: buildNameReviewerMap(fileToOwner),
+		unownedFiles:    []string{},
+	}
+}
+
 // A collection of owned files, with reverse lookups for owners and reviewers
 type ownersMap struct {
 	author          string

--- a/pkg/codeowners/codeowners.go
+++ b/pkg/codeowners/codeowners.go
@@ -48,7 +48,6 @@ func New(root string, files []DiffFile, fileReader FileReader, warningWriter io.
 	reviewerGroupManager := NewReviewerGroupMemo()
 	tree := initOwnerTreeNode(root, root, reviewerGroupManager, nil, fileReader, warningWriter)
 	tree.warningWriter = warningWriter
-	// TODO - support inline ownership rules (issue #3)
 	fileNames := f.Map(files, func(file DiffFile) string { return file.FileName })
 	testMap := tree.BuildFromFiles(fileNames, reviewerGroupManager)
 	ownersMap, err := testMap.getOwners(fileNames)

--- a/pkg/codeowners/diff.go
+++ b/pkg/codeowners/diff.go
@@ -7,5 +7,22 @@ type HunkRange struct {
 
 type DiffFile struct {
 	FileName string
-	Hunks    []HunkRange
+	// BaseFileName is the file's name in the base (original) revision when
+	// it differs from FileName (renames). Empty when the name is unchanged.
+	BaseFileName string
+	// Hunks are the changed line ranges in the head (new) revision.
+	Hunks []HunkRange
+	// BaseHunks are the changed line ranges in the base (original)
+	// revision. Needed by consumers that must see deleted content, such
+	// as inline ownership (a block removed in the PR only exists at base).
+	BaseHunks []HunkRange
+}
+
+// BaseName returns the file's name in the base revision, falling back to
+// FileName when the file was not renamed.
+func (d DiffFile) BaseName() string {
+	if d.BaseFileName != "" {
+		return d.BaseFileName
+	}
+	return d.FileName
 }

--- a/pkg/inlineowners/inlineowners.go
+++ b/pkg/inlineowners/inlineowners.go
@@ -1,0 +1,215 @@
+// Package inlineowners implements inline ownership: comment tags inside
+// source files that mark a region as owned, so changes touching that
+// region require the tagged owners' approval.
+//
+// A block looks like:
+//
+//	// <CO-inline={@alice,@team-a}>
+//	func Sensitive() { ... }
+//	// </CO-inline>
+//
+// Both `//` and `#` comment prefixes are supported, tag names are matched
+// case-insensitively, and owners may be separated by commas or spaces.
+// The owners inside one tag form an OR group (any listed owner satisfies
+// it), like a .codeowners line; overlapping blocks AND together.
+//
+// Blocks are parsed from both the base and head revisions of each changed
+// file, so deleting an owned region or editing its tag still requires the
+// owners recorded at base.
+package inlineowners
+
+import (
+	"fmt"
+	"io"
+	"regexp"
+	"strings"
+
+	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
+)
+
+// Requirement is a reviewer requirement derived from an inline ownership
+// block touched by the diff.
+type Requirement struct {
+	// File is the file's name in the head revision.
+	File string
+	// Owners is an OR group: any one of these reviewers satisfies it.
+	Owners []string
+	// Reason records which block produced the requirement, for verbose output.
+	Reason string
+}
+
+// Block is an inline ownership region in a single revision of a file.
+// Start and End are 1-based line numbers, inclusive of the tag lines
+// themselves: editing a tag line counts as touching the block, so
+// tampering with an ownership tag requires the tagged owners' approval.
+type Block struct {
+	Owners []string
+	Start  int
+	End    int
+}
+
+// Overlaps reports whether the block intersects the line range [start, end].
+func (b Block) Overlaps(start, end int) bool {
+	return end >= b.Start && start <= b.End
+}
+
+var (
+	startTagRe = regexp.MustCompile(`(?i)(?://|#)\s*<CO-inline=\{(?P<owners>[^}]*)\}>`)
+	endTagRe   = regexp.MustCompile(`(?i)(?://|#)\s*</CO-inline>`)
+	// After a start tag on the same line, the end tag is already inside a
+	// comment, so it does not need its own comment prefix.
+	endAnywhereRe = regexp.MustCompile(`(?i)</CO-inline>`)
+)
+
+// Parse scans file content for inline ownership blocks. Malformed
+// constructs (nested or unmatched tags, empty owner lists) produce
+// warnings on warn and are skipped, and an unclosed block extends to
+// end-of-file, so a missing end tag cannot silently remove protection.
+func Parse(content string, warn io.Writer) []Block {
+	blocks := []Block{}
+	inBlock := false
+	var current Block
+	lineNo := 0
+	for line := range strings.SplitSeq(content, "\n") {
+		lineNo++
+		line = strings.TrimSuffix(line, "\r")
+
+		startMatch := startTagRe.FindStringSubmatch(line)
+		var hasEnd bool
+		if startMatch != nil {
+			startLoc := startTagRe.FindStringIndex(line)
+			hasEnd = endAnywhereRe.MatchString(line[startLoc[1]:])
+		} else {
+			hasEnd = endTagRe.MatchString(line)
+		}
+
+		if startMatch != nil {
+			if inBlock {
+				_, _ = fmt.Fprintf(warn, "WARNING: Nested <CO-inline> tag at line %d ignored\n", lineNo)
+			} else {
+				owners := splitOwners(startMatch[startTagRe.SubexpIndex("owners")])
+				if len(owners) == 0 {
+					_, _ = fmt.Fprintf(warn, "WARNING: Empty owner list in <CO-inline> tag at line %d; block ignored\n", lineNo)
+				} else {
+					inBlock = true
+					current = Block{Owners: owners, Start: lineNo}
+				}
+			}
+		}
+
+		if hasEnd {
+			// An end tag on the start-tag line closes the block on that
+			// same line (a block covering just the tag line).
+			if inBlock {
+				current.End = lineNo
+				blocks = append(blocks, current)
+				inBlock = false
+			} else if startMatch == nil {
+				_, _ = fmt.Fprintf(warn, "WARNING: Unmatched </CO-inline> tag at line %d ignored\n", lineNo)
+			}
+		}
+	}
+	if inBlock {
+		_, _ = fmt.Fprintf(warn, "WARNING: Unclosed <CO-inline> tag at line %d; block extends to end of file\n", current.Start)
+		current.End = lineNo
+		blocks = append(blocks, current)
+	}
+	return blocks
+}
+
+// splitOwners splits a tag's owner list on commas and whitespace,
+// dropping empties and case-insensitive duplicates.
+func splitOwners(raw string) []string {
+	parts := strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == ' ' || r == '\t'
+	})
+	owners := make([]string, 0, len(parts))
+	seen := make(map[string]struct{}, len(parts))
+	for _, owner := range parts {
+		key := strings.ToLower(owner)
+		if _, dup := seen[key]; dup {
+			continue
+		}
+		seen[key] = struct{}{}
+		owners = append(owners, owner)
+	}
+	return owners
+}
+
+// Requirements computes reviewer requirements for the inline ownership
+// blocks touched by the diff. For each changed file it parses blocks from
+// the base revision (under the file's base name, checked against
+// BaseHunks) and the head revision (checked against Hunks) and emits one
+// requirement per touched block. A renamed file requires approval from
+// all of its base-revision block owners, since a pure rename produces no
+// hunks but still relocates the protected regions. A file absent at a
+// revision (added or deleted files) contributes no blocks for that side,
+// but a read failure for a file that exists is a hard error: proceeding
+// without its blocks would silently drop required reviews.
+func Requirements(
+	files []codeowners.DiffFile,
+	baseReader codeowners.FileReader,
+	headReader codeowners.FileReader,
+	warn io.Writer,
+) ([]Requirement, error) {
+	requirements := []Requirement{}
+	for _, file := range files {
+		renamed := file.BaseFileName != ""
+		baseReqs, err := revisionRequirements(file.BaseName(), file.FileName, file.BaseHunks, renamed, baseReader, "base", warn)
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, baseReqs...)
+		headReqs, err := revisionRequirements(file.FileName, file.FileName, file.Hunks, false, headReader, "head", warn)
+		if err != nil {
+			return nil, err
+		}
+		requirements = append(requirements, headReqs...)
+	}
+	return requirements, nil
+}
+
+func revisionRequirements(
+	readName string,
+	headName string,
+	hunks []codeowners.HunkRange,
+	allBlocks bool,
+	reader codeowners.FileReader,
+	revision string,
+	warn io.Writer,
+) ([]Requirement, error) {
+	if (len(hunks) == 0 && !allBlocks) || !reader.PathExists(readName) {
+		return nil, nil
+	}
+	content, err := reader.ReadFile(readName)
+	if err != nil {
+		return nil, fmt.Errorf("inline ownership: failed to read %s at %s: %w", readName, revision, err)
+	}
+	requirements := []Requirement{}
+	for _, block := range Parse(string(content), warn) {
+		if !allBlocks && !blockTouched(block, hunks) {
+			continue
+		}
+		requirements = append(requirements, Requirement{
+			File:   headName,
+			Owners: block.Owners,
+			Reason: fmt.Sprintf("inline ownership block at %s lines %d-%d", revision, block.Start, block.End),
+		})
+	}
+	return requirements, nil
+}
+
+func blockTouched(block Block, hunks []codeowners.HunkRange) bool {
+	for _, hunk := range hunks {
+		// A zero-length hunk (End < Start) is an insertion point on this
+		// side; it touches no lines here, and the other side's hunk
+		// covers the inserted or deleted content.
+		if hunk.End < hunk.Start {
+			continue
+		}
+		if block.Overlaps(hunk.Start, hunk.End) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/inlineowners/inlineowners_test.go
+++ b/pkg/inlineowners/inlineowners_test.go
@@ -1,0 +1,324 @@
+package inlineowners
+
+import (
+	"bytes"
+	"errors"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
+)
+
+func TestParse(t *testing.T) {
+	tt := []struct {
+		name            string
+		content         string
+		expectedBlocks  []Block
+		expectedWarning string
+	}{
+		{
+			name: "basic slash block",
+			content: strings.Join([]string{
+				"package foo",
+				"// <CO-inline={@alice,@team-a}>",
+				"func Sensitive() {}",
+				"// </CO-inline>",
+				"func Other() {}",
+			}, "\n"),
+			expectedBlocks: []Block{{Owners: []string{"@alice", "@team-a"}, Start: 2, End: 4}},
+		},
+		{
+			name: "hash block with indentation",
+			content: strings.Join([]string{
+				"class Foo:",
+				"    # <CO-inline={@model-owner}>",
+				"    field = 1",
+				"    # </CO-inline>",
+			}, "\n"),
+			expectedBlocks: []Block{{Owners: []string{"@model-owner"}, Start: 2, End: 4}},
+		},
+		{
+			name:           "space separated owners",
+			content:        "// <CO-inline={@alice @team-a}>\nx\n// </CO-inline>",
+			expectedBlocks: []Block{{Owners: []string{"@alice", "@team-a"}, Start: 1, End: 3}},
+		},
+		{
+			name:           "mixed comma and space separators",
+			content:        "// <CO-inline={@a, @b @c}>\nx\n// </CO-inline>",
+			expectedBlocks: []Block{{Owners: []string{"@a", "@b", "@c"}, Start: 1, End: 3}},
+		},
+		{
+			name:           "CRLF line endings",
+			content:        "// <CO-inline={@a}>\r\nx\r\n// </CO-inline>\r\n",
+			expectedBlocks: []Block{{Owners: []string{"@a"}, Start: 1, End: 3}},
+		},
+		{
+			name:           "case insensitive tags",
+			content:        "// <co-INLINE={@a}>\ncode\n// </Co-Inline>",
+			expectedBlocks: []Block{{Owners: []string{"@a"}, Start: 1, End: 3}},
+		},
+		{
+			name:           "multiple blocks",
+			content:        "// <CO-inline={@a}>\nx\n// </CO-inline>\ny\n// <CO-inline={@b}>\nz\n// </CO-inline>",
+			expectedBlocks: []Block{{Owners: []string{"@a"}, Start: 1, End: 3}, {Owners: []string{"@b"}, Start: 5, End: 7}},
+		},
+		{
+			name:           "owners deduped case-insensitively",
+			content:        "// <CO-inline={ @a , @b , @A }>\nx\n// </CO-inline>",
+			expectedBlocks: []Block{{Owners: []string{"@a", "@b"}, Start: 1, End: 3}},
+		},
+		{
+			name:            "unclosed block extends to EOF",
+			content:         "// <CO-inline={@a}>\nx\ny",
+			expectedBlocks:  []Block{{Owners: []string{"@a"}, Start: 1, End: 3}},
+			expectedWarning: "Unclosed",
+		},
+		{
+			name:            "nested start ignored",
+			content:         "// <CO-inline={@a}>\n// <CO-inline={@b}>\nx\n// </CO-inline>",
+			expectedBlocks:  []Block{{Owners: []string{"@a"}, Start: 1, End: 4}},
+			expectedWarning: "Nested",
+		},
+		{
+			name:            "stray end tag ignored",
+			content:         "x\n// </CO-inline>\ny",
+			expectedBlocks:  []Block{},
+			expectedWarning: "Unmatched",
+		},
+		{
+			name:            "empty owner list ignored",
+			content:         "// <CO-inline={}>\nx\n// </CO-inline>",
+			expectedBlocks:  []Block{},
+			expectedWarning: "Empty owner list",
+		},
+		{
+			name:           "same line open and close",
+			content:        "// <CO-inline={@a}> </CO-inline>\nx",
+			expectedBlocks: []Block{{Owners: []string{"@a"}, Start: 1, End: 1}},
+		},
+		{
+			name:           "no tags",
+			content:        "just\ncode",
+			expectedBlocks: []Block{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			warn := &bytes.Buffer{}
+			blocks := Parse(tc.content, warn)
+			if !reflect.DeepEqual(blocks, tc.expectedBlocks) {
+				t.Errorf("blocks mismatch:\n got %+v\nexpected %+v", blocks, tc.expectedBlocks)
+			}
+			if tc.expectedWarning != "" && !strings.Contains(warn.String(), tc.expectedWarning) {
+				t.Errorf("expected warning containing %q, got %q", tc.expectedWarning, warn.String())
+			}
+			if tc.expectedWarning == "" && warn.Len() > 0 {
+				t.Errorf("unexpected warnings: %q", warn.String())
+			}
+		})
+	}
+}
+
+func TestBlockOverlaps(t *testing.T) {
+	block := Block{Start: 5, End: 10}
+	tt := []struct {
+		name       string
+		start, end int
+		expected   bool
+	}{
+		{name: "before block", start: 1, end: 4, expected: false},
+		{name: "touching start", start: 1, end: 5, expected: true},
+		{name: "inside block", start: 7, end: 8, expected: true},
+		{name: "touching end", start: 10, end: 20, expected: true},
+		{name: "after block", start: 11, end: 20, expected: false},
+	}
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			if result := block.Overlaps(tc.start, tc.end); result != tc.expected {
+				t.Errorf("Overlaps(%d, %d) = %t, expected %t", tc.start, tc.end, result, tc.expected)
+			}
+		})
+	}
+}
+
+// mapReader is an in-memory FileReader keyed by path.
+type mapReader map[string]string
+
+func (m mapReader) ReadFile(path string) ([]byte, error) {
+	content, ok := m[path]
+	if !ok {
+		return nil, errors.New("not found")
+	}
+	return []byte(content), nil
+}
+
+func (m mapReader) PathExists(path string) bool {
+	_, ok := m[path]
+	return ok
+}
+
+func ownersByFile(requirements []Requirement) map[string][]string {
+	result := make(map[string][]string)
+	for _, requirement := range requirements {
+		for _, owner := range requirement.Owners {
+			if !slices.Contains(result[requirement.File], owner) {
+				result[requirement.File] = append(result[requirement.File], owner)
+			}
+		}
+	}
+	return result
+}
+
+func TestRequirements(t *testing.T) {
+	ownedBase := "// <CO-inline={@guard}>\nline2\nline3\n// </CO-inline>\nline5"
+	base := mapReader{
+		"owned.go":   ownedBase,
+		"deleted.go": "// <CO-inline={@keeper}>\nprecious\n// </CO-inline>",
+		"plain.go":   "nothing\nspecial",
+	}
+	head := mapReader{
+		"owned.go": ownedBase + "\nline6",
+		// deleted.go removed at head
+		"plain.go": "nothing\nspecial\nnew line",
+		"added.go": "// <CO-inline={@newbie}>\nfresh\n// </CO-inline>",
+	}
+
+	files := []codeowners.DiffFile{
+		// change inside the owned block (head line 2, base line 2)
+		{FileName: "owned.go", Hunks: []codeowners.HunkRange{{Start: 2, End: 2}}, BaseHunks: []codeowners.HunkRange{{Start: 2, End: 2}}},
+		// whole file deleted: only base hunks
+		{FileName: "deleted.go", Hunks: []codeowners.HunkRange{{Start: 0, End: -1}}, BaseHunks: []codeowners.HunkRange{{Start: 1, End: 3}}},
+		// change outside any block
+		{FileName: "plain.go", Hunks: []codeowners.HunkRange{{Start: 3, End: 3}}, BaseHunks: []codeowners.HunkRange{{Start: 2, End: 2}}},
+		// new file with a block
+		{FileName: "added.go", Hunks: []codeowners.HunkRange{{Start: 1, End: 3}}, BaseHunks: []codeowners.HunkRange{{Start: 0, End: -1}}},
+	}
+
+	warn := &bytes.Buffer{}
+	requirements, err := Requirements(files, base, head, warn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	owners := ownersByFile(requirements)
+	expected := map[string][]string{
+		"owned.go":   {"@guard"},  // touched block (base and head)
+		"deleted.go": {"@keeper"}, // block only exists at base
+		"added.go":   {"@newbie"}, // block only exists at head
+	}
+	if !reflect.DeepEqual(owners, expected) {
+		t.Errorf("owners mismatch:\n got %v\nexpected %v", owners, expected)
+	}
+	// owned.go is touched at base and head: one requirement per revision
+	if len(requirements) != 4 {
+		t.Errorf("expected 4 requirements (owned x2, deleted, added), got %+v", requirements)
+	}
+}
+
+func TestRequirementsChangeOutsideBlock(t *testing.T) {
+	content := "line1\n// <CO-inline={@guard}>\nline3\n// </CO-inline>\nline5"
+	readers := mapReader{"a.go": content}
+	files := []codeowners.DiffFile{
+		{FileName: "a.go", Hunks: []codeowners.HunkRange{{Start: 5, End: 5}}, BaseHunks: []codeowners.HunkRange{{Start: 5, End: 5}}},
+	}
+	requirements, err := Requirements(files, readers, readers, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requirements) != 0 {
+		t.Errorf("expected no requirements for change outside block, got %+v", requirements)
+	}
+}
+
+func TestRequirementsEmptyHunkDoesNotTouchBlock(t *testing.T) {
+	// A pure insertion right after a block produces a zero-length hunk on
+	// the base side (e.g. @@ -3,0 +4 @@ -> base range {3, 2}); it touches
+	// no base lines, so the block's owners must not be required.
+	content := "// <CO-inline={@guard}>\nline2\n// </CO-inline>\nline4"
+	readers := mapReader{"a.go": content}
+	files := []codeowners.DiffFile{
+		{FileName: "a.go", Hunks: []codeowners.HunkRange{{Start: 4, End: 4}}, BaseHunks: []codeowners.HunkRange{{Start: 3, End: 2}}},
+	}
+	requirements, err := Requirements(files, readers, readers, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requirements) != 0 {
+		t.Errorf("zero-length hunk must not touch the block, got %+v", requirements)
+	}
+}
+
+func TestRequirementsTagLineEditTriggersOwners(t *testing.T) {
+	baseContent := "line1\n// <CO-inline={@guard}>\nline3\n// </CO-inline>\nline5"
+	headContent := "line1\n// <CO-inline={@attacker}>\nline3\n// </CO-inline>\nline5"
+	base := mapReader{"a.go": baseContent}
+	head := mapReader{"a.go": headContent}
+	// only the tag line (line 2) changed
+	files := []codeowners.DiffFile{
+		{FileName: "a.go", Hunks: []codeowners.HunkRange{{Start: 2, End: 2}}, BaseHunks: []codeowners.HunkRange{{Start: 2, End: 2}}},
+	}
+	requirements, err := Requirements(files, base, head, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !slices.Contains(ownersByFile(requirements)["a.go"], "@guard") {
+		t.Errorf("editing the tag line must still require the base owners, got %+v", requirements)
+	}
+}
+
+func TestRequirementsRenamedFile(t *testing.T) {
+	// A pure rename produces no hunks, but relocating protected regions
+	// still requires the base blocks' owners; requirements target the
+	// head file name.
+	base := mapReader{"old.go": "// <CO-inline={@guard}>\ncontent\n// </CO-inline>\nplain"}
+	head := mapReader{"new.go": "// <CO-inline={@guard}>\ncontent\n// </CO-inline>\nplain"}
+	files := []codeowners.DiffFile{
+		{FileName: "new.go", BaseFileName: "old.go"},
+	}
+	requirements, err := Requirements(files, base, head, &bytes.Buffer{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requirements) != 1 {
+		t.Fatalf("expected 1 requirement for renamed file's block, got %+v", requirements)
+	}
+	if requirements[0].File != "new.go" || !slices.Contains(requirements[0].Owners, "@guard") {
+		t.Errorf("expected @guard requirement on new.go, got %+v", requirements[0])
+	}
+}
+
+func TestRequirementsMissingFilesAreSilent(t *testing.T) {
+	files := []codeowners.DiffFile{
+		{FileName: "gone.go", Hunks: []codeowners.HunkRange{{Start: 1, End: 1}}, BaseHunks: []codeowners.HunkRange{{Start: 1, End: 1}}},
+	}
+	warn := &bytes.Buffer{}
+	requirements, err := Requirements(files, mapReader{}, mapReader{}, warn)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(requirements) != 0 {
+		t.Errorf("expected no requirements, got %+v", requirements)
+	}
+	if warn.Len() != 0 {
+		t.Errorf("missing files should be silent (added/deleted are normal), got %q", warn.String())
+	}
+}
+
+// failReader claims every path exists but fails to read it.
+type failReader struct{}
+
+func (failReader) ReadFile(path string) ([]byte, error) { return nil, errors.New("boom") }
+func (failReader) PathExists(path string) bool          { return true }
+
+func TestRequirementsReadErrorFailsClosed(t *testing.T) {
+	files := []codeowners.DiffFile{
+		{FileName: "a.go", Hunks: []codeowners.HunkRange{{Start: 1, End: 1}}, BaseHunks: []codeowners.HunkRange{{Start: 1, End: 1}}},
+	}
+	_, err := Requirements(files, failReader{}, failReader{}, &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "failed to read") {
+		t.Errorf("expected hard error for unreadable existing file, got %v", err)
+	}
+}

--- a/pkg/oracle/oracle.go
+++ b/pkg/oracle/oracle.go
@@ -1,0 +1,137 @@
+// Package oracle implements ownership oracles: reviewer requirements
+// produced by tooling outside the .codeowners file tree (for example a
+// semantic diff analyzer) and fed into codeowners-plus as data.
+//
+// An oracle file is JSON:
+//
+//	{
+//	  "rules": [
+//	    {
+//	      "files": ["src/telemetry/**", "src/events.py"],
+//	      "owners": ["@org/data-platform"],
+//	      "optional": false,
+//	      "reason": "telemetry event schema changed"
+//	    }
+//	  ]
+//	}
+//
+// Each rule's owners form a single OR group (any listed owner satisfies the
+// rule), matching .codeowners semantics. Distinct rules matching the same
+// file are AND-ed together. Oracle rules can only ADD reviewer requirements.
+package oracle
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/bmatcuk/doublestar/v4"
+	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
+)
+
+// Rule is a single oracle reviewer requirement.
+type Rule struct {
+	// Files are doublestar glob patterns matched against full paths of
+	// files changed in the PR, relative to the repository root.
+	Files []string `json:"files"`
+	// Owners is an OR group: any one of these reviewers satisfies the rule.
+	Owners []string `json:"owners"`
+	// Optional marks the owners as non-blocking (CC'd instead of required).
+	Optional bool `json:"optional"`
+	// Reason is a human-readable explanation of why the rule exists.
+	// It is surfaced in verbose output only.
+	Reason string `json:"reason"`
+}
+
+// RuleSet is the parsed contents of an oracle file.
+type RuleSet struct {
+	Rules []Rule `json:"rules"`
+}
+
+// Parse decodes and validates oracle file contents. Validation is strict:
+// a rule that cannot take effect (no files, no owners, or an invalid glob
+// pattern) is an error, since skipping it would drop required reviews.
+func Parse(data []byte) (*RuleSet, error) {
+	var ruleSet RuleSet
+	if err := json.Unmarshal(data, &ruleSet); err != nil {
+		return nil, fmt.Errorf("invalid oracle JSON: %w", err)
+	}
+	for i, rule := range ruleSet.Rules {
+		if len(rule.Files) == 0 {
+			return nil, fmt.Errorf("oracle rule %d has no files", i)
+		}
+		for _, pattern := range rule.Files {
+			// An empty pattern is "valid" per doublestar but matches
+			// nothing, which would silently disable the rule.
+			if pattern == "" || !doublestar.ValidatePattern(pattern) {
+				return nil, fmt.Errorf("oracle rule %d has an invalid pattern %q", i, pattern)
+			}
+		}
+		if len(rule.Owners) == 0 {
+			return nil, fmt.Errorf("oracle rule %d has no owners", i)
+		}
+		for _, owner := range rule.Owners {
+			if owner == "" {
+				return nil, fmt.Errorf("oracle rule %d has an empty owner", i)
+			}
+		}
+	}
+	return &ruleSet, nil
+}
+
+// Load reads and parses an oracle file from disk.
+func Load(path string) (*RuleSet, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("reading oracle file: %w", err)
+	}
+	ruleSet, err := Parse(data)
+	if err != nil {
+		return nil, fmt.Errorf("oracle file %s: %w", path, err)
+	}
+	return ruleSet, nil
+}
+
+// ToCodeOwners builds a codeowners.CodeOwners containing the rule set's
+// requirements for the given changed files. Files matching no rule are
+// omitted entirely, so the result is suitable for AND-merging into the
+// .codeowners-derived ownership via codeowners.MergeCodeOwners.
+func (rs *RuleSet) ToCodeOwners(changedFiles []string, warningWriter io.Writer) codeowners.CodeOwners {
+	if warningWriter == nil {
+		warningWriter = io.Discard
+	}
+	rgm := codeowners.NewReviewerGroupMemo()
+	required := make(map[string]codeowners.ReviewerGroups)
+	optional := make(map[string]codeowners.ReviewerGroups)
+	for _, rule := range rs.Rules {
+		group := rgm.ToReviewerGroup(rule.Owners...)
+		target := required
+		if rule.Optional {
+			target = optional
+		}
+		for _, file := range changedFiles {
+			if !rule.matches(file, warningWriter) {
+				continue
+			}
+			target[file] = append(target[file], group)
+		}
+	}
+	return codeowners.NewFromFileOwners(required, optional)
+}
+
+func (r *Rule) matches(file string, warningWriter io.Writer) bool {
+	for _, pattern := range r.Files {
+		// Parse rejects invalid patterns, but a RuleSet can also be
+		// constructed directly, so pattern errors are still handled.
+		match, err := doublestar.Match(pattern, file)
+		if err != nil {
+			_, _ = fmt.Fprintf(warningWriter, "WARNING: PatternError for oracle pattern '%s': %s\n", pattern, err)
+			continue
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/oracle/oracle_test.go
+++ b/pkg/oracle/oracle_test.go
@@ -1,0 +1,203 @@
+package oracle
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
+)
+
+func TestParse(t *testing.T) {
+	tt := []struct {
+		name          string
+		input         string
+		expectedRules int
+		expectedErr   string
+	}{
+		{
+			name:          "valid rule set",
+			input:         `{"rules": [{"files": ["a/**"], "owners": ["@team-a"], "reason": "test"}]}`,
+			expectedRules: 1,
+		},
+		{
+			name:          "empty rules",
+			input:         `{"rules": []}`,
+			expectedRules: 0,
+		},
+		{
+			name:          "no rules key",
+			input:         `{}`,
+			expectedRules: 0,
+		},
+		{
+			name:        "invalid JSON",
+			input:       `{"rules": [`,
+			expectedErr: "invalid oracle JSON",
+		},
+		{
+			name:        "rule without files",
+			input:       `{"rules": [{"files": [], "owners": ["@team-a"]}]}`,
+			expectedErr: "rule 0 has no files",
+		},
+		{
+			name:        "rule with invalid pattern",
+			input:       `{"rules": [{"files": ["[invalid"], "owners": ["@team-a"]}]}`,
+			expectedErr: `rule 0 has an invalid pattern "[invalid"`,
+		},
+		{
+			name:        "rule with empty pattern",
+			input:       `{"rules": [{"files": [""], "owners": ["@team-a"]}]}`,
+			expectedErr: `rule 0 has an invalid pattern ""`,
+		},
+		{
+			name:        "rule without owners",
+			input:       `{"rules": [{"files": ["a.go"], "owners": []}]}`,
+			expectedErr: "rule 0 has no owners",
+		},
+		{
+			name:        "rule with empty owner",
+			input:       `{"rules": [{"files": ["a.go"], "owners": [""]}]}`,
+			expectedErr: "rule 0 has an empty owner",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			ruleSet, err := Parse([]byte(tc.input))
+			if tc.expectedErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tc.expectedErr) {
+					t.Fatalf("expected error containing %q, got %v", tc.expectedErr, err)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(ruleSet.Rules) != tc.expectedRules {
+				t.Errorf("expected %d rules, got %d", tc.expectedRules, len(ruleSet.Rules))
+			}
+		})
+	}
+}
+
+func TestLoad(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "oracle.json")
+	content := `{"rules": [{"files": ["src/**"], "owners": ["@org/data-platform"], "reason": "telemetry"}]}`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ruleSet, err := Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ruleSet.Rules) != 1 || ruleSet.Rules[0].Owners[0] != "@org/data-platform" {
+		t.Errorf("unexpected rule set: %+v", ruleSet)
+	}
+
+	if _, err := Load(filepath.Join(dir, "missing.json")); err == nil {
+		t.Error("expected error for missing file")
+	}
+
+	badPath := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(badPath, []byte("not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(badPath); err == nil || !strings.Contains(err.Error(), badPath) {
+		t.Errorf("expected error naming the file, got %v", err)
+	}
+}
+
+func requiredNames(co codeowners.CodeOwners, file string) []string {
+	groups, ok := co.FileRequired()[file]
+	if !ok {
+		return nil
+	}
+	return codeowners.OriginalStrings(groups.Flatten())
+}
+
+func TestToCodeOwners(t *testing.T) {
+	ruleSet := &RuleSet{Rules: []Rule{
+		{Files: []string{"src/telemetry/**"}, Owners: []string{"@org/data-platform"}, Reason: "telemetry"},
+		{Files: []string{"src/telemetry/events.ts"}, Owners: []string{"@org/frontend"}},
+		{Files: []string{"docs/**"}, Owners: []string{"@org/docs"}, Optional: true},
+	}}
+	changed := []string{
+		"src/telemetry/events.ts",
+		"src/telemetry/nested/deep.py",
+		"docs/readme.md",
+		"unrelated/main.go",
+	}
+
+	warnings := &bytes.Buffer{}
+	co := ruleSet.ToCodeOwners(changed, warnings)
+
+	// Two rules match events.ts: their groups AND together
+	names := requiredNames(co, "src/telemetry/events.ts")
+	if !slices.Contains(names, "@org/data-platform") || !slices.Contains(names, "@org/frontend") {
+		t.Errorf("expected both oracle owners for events.ts, got %v", names)
+	}
+	if len(co.FileRequired()["src/telemetry/events.ts"]) != 2 {
+		t.Errorf("expected 2 AND groups for events.ts, got %d", len(co.FileRequired()["src/telemetry/events.ts"]))
+	}
+
+	// Globstar matches nested files
+	if names := requiredNames(co, "src/telemetry/nested/deep.py"); !slices.Contains(names, "@org/data-platform") {
+		t.Errorf("expected data-platform for nested file, got %v", names)
+	}
+
+	// Optional rules go to FileOptional, not FileRequired
+	if _, ok := co.FileRequired()["docs/readme.md"]; ok {
+		t.Error("optional rule should not create required reviewers")
+	}
+	optional := co.FileOptional()["docs/readme.md"]
+	if len(optional) != 1 || !slices.Contains(codeowners.OriginalStrings(optional.Flatten()), "@org/docs") {
+		t.Errorf("expected optional docs owner, got %v", optional)
+	}
+
+	// Unmatched files are not tracked and not unowned
+	if _, ok := co.FileRequired()["unrelated/main.go"]; ok {
+		t.Error("unmatched file should not be tracked")
+	}
+	if len(co.UnownedFiles()) != 0 {
+		t.Errorf("oracle CodeOwners should report no unowned files, got %v", co.UnownedFiles())
+	}
+
+	// Approvals satisfy oracle groups, case-insensitively
+	co.ApplyApprovals([]codeowners.Slug{codeowners.NewSlug("@ORG/Data-Platform")})
+	if names := requiredNames(co, "src/telemetry/nested/deep.py"); len(names) != 0 {
+		t.Errorf("expected no remaining required reviewers after approval, got %v", names)
+	}
+}
+
+func TestToCodeOwnersNilWarningWriter(t *testing.T) {
+	ruleSet := &RuleSet{Rules: []Rule{
+		{Files: []string{"[invalid"}, Owners: []string{"@org/data-platform"}},
+	}}
+	// Must not panic: the bad pattern's warning goes to io.Discard.
+	co := ruleSet.ToCodeOwners([]string{"a.go"}, nil)
+	if len(co.FileRequired()) != 0 {
+		t.Errorf("bad pattern should match nothing, got %v", co.FileRequired())
+	}
+}
+
+func TestToCodeOwnersBadPattern(t *testing.T) {
+	// Parse rejects invalid patterns, but a RuleSet constructed directly
+	// can still carry one; matching warns and skips the pattern.
+	ruleSet := &RuleSet{Rules: []Rule{
+		{Files: []string{"[invalid"}, Owners: []string{"@org/data-platform"}},
+	}}
+	warnings := &bytes.Buffer{}
+	co := ruleSet.ToCodeOwners([]string{"a.go"}, warnings)
+	if len(co.FileRequired()) != 0 {
+		t.Errorf("bad pattern should match nothing, got %v", co.FileRequired())
+	}
+	if !strings.Contains(warnings.String(), "PatternError") {
+		t.Errorf("expected pattern warning, got %q", warnings.String())
+	}
+}


### PR DESCRIPTION
Closes #3

## Related PR(s)

Stacked on #178 (uses `NewFromFileOwners` and the same `MergeCodeOwners` merge path); only the top commit is new. Supersedes #45, which can be closed.

## Related Issue(s)

Resolves #3. The issue floats AST-anchored comments (tree-sitter); this ships the language-agnostic line-range block form first, with AST anchoring noted in Future Features.

## Summary / Background

Inline ownership: comment tags that mark a region of a source file as owned, so PR changes touching that region require the tagged owners' approval.

```go
// <CO-inline={@alice,@security-team}>
func ValidateToken(token string) bool { ... }
// </CO-inline>
```

`//` and `#` prefixes work, tags are case-insensitive, and owners may be separated by commas or spaces. Owners inside one tag form an OR group, like a `.codeowners` line; overlapping blocks AND together. Enabled per-repo via `enable_inline_ownership = true` in `codeowners.toml` (default off).

Touched blocks become per-file reviewer requirements, AND-merged into `.codeowners`-derived ownership via `codeowners.MergeCodeOwners` (the same mechanism as `require_both_branch_reviewers` and oracle files), so inline ownership can only ever add requirements.

Design points:

- Blocks are parsed from both the merge-base and head revisions of each changed file. Hunk coordinates come from the three-dot diff, so the base side reads at the merge base (`git merge-base`), not the base branch tip; otherwise line ranges drift whenever the base branch has advanced.
- Renames are followed: the base revision is read under the old name, and a pure rename requires approval from all of the file's block owners. The ignore-dirs diff filter now keeps files whose old path is not ignored, so renaming a file into an ignored directory cannot hide it.
- Tag lines are part of the protected range, so editing an ownership tag requires the owners recorded at base.
- Fail-closed: a file that exists at a revision but cannot be read is a hard error. Zero-length hunks (pure insertion points) do not count as touching an adjacent block.

## Code Changes

- `pkg/inlineowners`: block parser + `Requirements` (block/hunk intersection)
- `internal/git`: `MergeBase` helper; `DiffFile.BaseHunks`/`BaseFileName`; both-path ignore-dirs filter; `changesSince` carries base fields
- `internal/config`: `enable_inline_ownership` (default false)
- `internal/app`: `applyInlineOwnership` merge step reading base blocks at the merge base
- README: "Inline Ownership" section; coverage badge regenerated
- Tests: parser table tests (incl. CRLF, space/comma separators), requirement unit tests (rename, zero-length hunks, tag tampering, fail-closed reads), config parse test, diff-parsing tests for the new fields, and real-git e2e tests covering edit/tamper/delete/rename shapes plus an advanced-base-branch scenario
