### PR TITLE
feat: add the [approval_retention] config section

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,10 @@ disable_review_status_comments = false
 # `admin_bypass` allows repository administrators to bypass codeowner requirements
 [admin_bypass]
 # see "Admin Bypass" below for more details
+
+# `approval_retention` allows you to specify which kinds of changes may keep an existing approval
+[approval_retention]
+# see "Approval Retention" below for more details
 ```
 
 When a PR has any of the `high_priority_labels`, the comment will look like this:
@@ -329,6 +333,38 @@ To trigger the admin bypass feature, **Create an approval review containing "Cod
 Codeowners Plus automatically detects and validates the bypass approval, immediately marking the PR as passing all codeowner requirements.
 
 The bypass text is case-insensitive, so "codeowners bypass", "Codeowners Bypass", or "CODEOWNERS BYPASS" all work.
+
+#### Approval Retention
+
+The `approval_retention` section lists the kinds of changes which may keep an existing approval instead of dismissing it. Everything in it is opt-in: `enabled` turns the section on, and each kind of change has to be named as well. Upgrading never changes how your approvals behave.
+
+`codeowners.toml`:
+```toml
+[approval_retention]
+# `enabled` (default false) turns the section on. On its own it retains nothing.
+enabled = true
+# Each flag below defaults to false and has to be asked for by name.
+# `whitespace` retains approvals across whitespace-only changes
+whitespace = true
+# `comments` retains approvals across comment-only changes
+comments = true
+# `formatting` retains approvals across formatting-only changes
+formatting = true
+# `string_literals` retains approvals across string literal changes
+string_literals = false
+# `renames` retains approvals across renames
+renames = false
+# `fetch_orphaned_approval` looks for approvals which are no longer
+#  attached to the current commit
+fetch_orphaned_approval = false
+```
+
+- Nothing set: every flag is off
+- `enabled = true` and nothing else: every flag is still off
+- `enabled = false` with flags set to `true`: every flag is off, so the section is a single kill switch
+- `enabled = true` with `whitespace = true`: whitespace only
+
+What counts as a change not worth re-reviewing is a judgement about a particular codebase, not something to inherit from a default. Two flags deserve extra thought before you name them. A change to a string literal or a rename can alter behavior without changing the shape of the code the approver reviewed, so retaining an approval across one is a stronger claim than the other categories. And `fetch_orphaned_approval` is the only flag in the section which reaches outside the checkout, so it adds network calls to a run.
 
 #### Require Both Branch Reviewers (Ownership Handoffs)
 

--- a/internal/app/approval_retention_test.go
+++ b/internal/app/approval_retention_test.go
@@ -1,0 +1,224 @@
+package app
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+	"github.com/multimediallc/codeowners-plus/internal/git"
+	gh "github.com/multimediallc/codeowners-plus/internal/github"
+	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
+)
+
+// The shared mock approves everything without reading the diff, which is the
+// decision under test, so the real staleness check is spliced back in.
+type realCheckApprovalsClient struct {
+	*mockGitHubClient
+	real      gh.Client
+	dismissed []*gh.CurrentApproval
+}
+
+func (c *realCheckApprovalsClient) CheckApprovals(
+	fileReviewerMap map[string][]string,
+	approvals []*gh.CurrentApproval,
+	originalDiff git.Diff,
+) ([]codeowners.Slug, []*gh.CurrentApproval) {
+	return c.real.CheckApprovals(fileReviewerMap, approvals, originalDiff)
+}
+
+func (c *realCheckApprovalsClient) DismissStaleReviews(approvals []*gh.CurrentApproval) error {
+	c.dismissed = append(c.dismissed, approvals...)
+	return c.mockGitHubClient.DismissStaleReviews(approvals)
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s (in %s): %v\n%s", strings.Join(args, " "), dir, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func initRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGit(t, dir, "init", "-q", "-b", "main")
+	runGit(t, dir, "config", "user.email", "test@example.invalid")
+	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "commit.gpgsign", "false")
+}
+
+func writeRepoFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir for %s: %v", name, err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func commitAll(t *testing.T, dir, message string) string {
+	t.Helper()
+	runGit(t, dir, "add", "-A")
+	runGit(t, dir, "commit", "-q", "-m", message)
+	return runGit(t, dir, "rev-parse", "HEAD")
+}
+
+func runApp(t *testing.T, repoDir, baseSHA, headSHA, approvalSHA string) (*OutputData, []*gh.CurrentApproval, string) {
+	t.Helper()
+
+	warnings := &bytes.Buffer{}
+	info := &bytes.Buffer{}
+
+	realClient, err := gh.NewClient("test-owner", "test-repo", "test-token")
+	if err != nil {
+		t.Fatalf("failed to build the real client: %v", err)
+	}
+	realClient.SetWarningBuffer(warnings)
+	realClient.SetInfoBuffer(info)
+
+	client := &realCheckApprovalsClient{
+		mockGitHubClient: &mockGitHubClient{
+			pr: &github.PullRequest{
+				Number: github.Ptr(1),
+				Base:   &github.PullRequestBranch{SHA: github.Ptr(baseSHA)},
+				Head:   &github.PullRequestBranch{SHA: github.Ptr(headSHA)},
+				User:   &github.User{Login: github.Ptr("author")},
+			},
+			currentApprovals: []*gh.CurrentApproval{{
+				GHLogin:   codeowners.NewSlug("@reviewer"),
+				ReviewID:  1,
+				Reviewers: []codeowners.Slug{codeowners.NewSlug("@owner")},
+				CommitID:  approvalSHA,
+			}},
+		},
+		real: realClient,
+	}
+
+	app := &App{
+		config: &Config{
+			RepoDir:       repoDir,
+			PR:            1,
+			Quiet:         true,
+			InfoBuffer:    info,
+			WarningBuffer: warnings,
+		},
+		client: client,
+	}
+
+	output, err := app.Run()
+	if err != nil {
+		t.Fatalf("app.Run failed: %v\nwarnings: %s", err, warnings)
+	}
+	return output, client.dismissed, warnings.String()
+}
+
+const retentionBaseSource = `package service
+
+func Alpha() int {
+	return 1
+}
+
+func Beta() int {
+	return 2
+}
+`
+
+// retentionApprovedSource is the change the reviewer approved.
+const retentionApprovedSource = `package service
+
+func Alpha() int {
+	return 1
+}
+
+func Beta() int {
+	return 20
+}
+`
+
+// Adds a comment and nothing else, so a comment is all the reviewer has not seen.
+const retentionHeadSource = `package service
+
+// Alpha is the first step.
+func Alpha() int {
+	return 1
+}
+
+func Beta() int {
+	return 20
+}
+`
+
+// configBody is committed as codeowners.toml on the base ref, which is where the
+// application reads its configuration from.
+func buildCommentOnlyRepo(t *testing.T, configBody string) (repoDir, baseSHA, headSHA, approvalSHA string) {
+	t.Helper()
+	repoDir = t.TempDir()
+	initRepo(t, repoDir)
+
+	writeRepoFile(t, repoDir, ".codeowners", "* @owner\n")
+	writeRepoFile(t, repoDir, "codeowners.toml", configBody)
+	writeRepoFile(t, repoDir, "service.go", retentionBaseSource)
+	baseSHA = commitAll(t, repoDir, "base")
+
+	writeRepoFile(t, repoDir, "service.go", retentionApprovedSource)
+	approvalSHA = commitAll(t, repoDir, "approved change")
+
+	writeRepoFile(t, repoDir, "service.go", retentionHeadSource)
+	headSHA = commitAll(t, repoDir, "comment on top of the approved change")
+
+	return repoDir, baseSHA, headSHA, approvalSHA
+}
+
+const retentionOffConfig = `disable_review_status_comments = true
+`
+
+// The feature is inert until asked for: no section and an all-off section have to
+// produce the same bytes.
+func TestRunWithoutRetentionSectionIsUnchanged(t *testing.T) {
+	const explicitlyOff = `disable_review_status_comments = true
+
+[approval_retention]
+enabled = false
+whitespace = false
+comments = false
+formatting = false
+string_literals = false
+renames = false
+fetch_orphaned_approval = false
+`
+
+	repoDir, baseSHA, headSHA, approvalSHA := buildCommentOnlyRepo(t, retentionOffConfig)
+	absentOutput, absentDismissed, absentWarnings := runApp(t, repoDir, baseSHA, headSHA, approvalSHA)
+
+	repoDir, baseSHA, headSHA, approvalSHA = buildCommentOnlyRepo(t, explicitlyOff)
+	offOutput, offDismissed, offWarnings := runApp(t, repoDir, baseSHA, headSHA, approvalSHA)
+
+	if absentOutput.Message != offOutput.Message || absentOutput.Success != offOutput.Success {
+		t.Errorf("expected identical results, got %+v and %+v", absentOutput, offOutput)
+	}
+	if !slices.Equal(absentOutput.StillRequired, offOutput.StillRequired) {
+		t.Errorf("expected identical still required, got %v and %v", absentOutput.StillRequired, offOutput.StillRequired)
+	}
+	if len(absentDismissed) != len(offDismissed) {
+		t.Errorf("expected identical dismissals, got %d and %d", len(absentDismissed), len(offDismissed))
+	}
+	if absentWarnings != offWarnings {
+		t.Errorf("expected identical warnings, got %q and %q", absentWarnings, offWarnings)
+	}
+	// Both are the pre-feature behavior, not merely equal to each other.
+	if len(absentDismissed) != 1 || absentOutput.Success {
+		t.Errorf("expected the approval to be dismissed as it always was, got %d dismissals, success %t",
+			len(absentDismissed), absentOutput.Success)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,20 +8,21 @@ import (
 )
 
 type Config struct {
-	MaxReviews                  *int         `toml:"max_reviews"`
-	MinReviews                  *int         `toml:"min_reviews"`
-	UnskippableReviewers        []string     `toml:"unskippable_reviewers"`
-	Ignore                      []string     `toml:"ignore"`
-	Enforcement                 *Enforcement `toml:"enforcement"`
-	HighPriorityLabels          []string     `toml:"high_priority_labels"`
-	AdminBypass                 *AdminBypass `toml:"admin_bypass"`
-	DetailedReviewers           bool         `toml:"detailed_reviewers"`
-	DisableSmartDismissal       bool         `toml:"disable_smart_dismissal"`
-	RequireBothBranchReviewers  bool         `toml:"require_both_branch_reviewers"`
-	SuppressUnownedWarning      bool         `toml:"suppress_unowned_warning"`
-	AllowSelfApproval           bool         `toml:"allow_self_approval"`
-	SelfApprovalViaTeams        bool         `toml:"self_approval_via_teams"`
-	DisableReviewStatusComments bool         `toml:"disable_review_status_comments"`
+	MaxReviews                  *int               `toml:"max_reviews"`
+	MinReviews                  *int               `toml:"min_reviews"`
+	UnskippableReviewers        []string           `toml:"unskippable_reviewers"`
+	Ignore                      []string           `toml:"ignore"`
+	Enforcement                 *Enforcement       `toml:"enforcement"`
+	HighPriorityLabels          []string           `toml:"high_priority_labels"`
+	AdminBypass                 *AdminBypass       `toml:"admin_bypass"`
+	ApprovalRetention           *ApprovalRetention `toml:"approval_retention"`
+	DetailedReviewers           bool               `toml:"detailed_reviewers"`
+	DisableSmartDismissal       bool               `toml:"disable_smart_dismissal"`
+	RequireBothBranchReviewers  bool               `toml:"require_both_branch_reviewers"`
+	SuppressUnownedWarning      bool               `toml:"suppress_unowned_warning"`
+	AllowSelfApproval           bool               `toml:"allow_self_approval"`
+	SelfApprovalViaTeams        bool               `toml:"self_approval_via_teams"`
+	DisableReviewStatusComments bool               `toml:"disable_review_status_comments"`
 }
 
 type Enforcement struct {
@@ -32,6 +33,66 @@ type Enforcement struct {
 type AdminBypass struct {
 	Enabled      bool     `toml:"enabled"`
 	AllowedUsers []string `toml:"allowed_users"`
+}
+
+// ApprovalRetention lists the kinds of diff change which may retain an approval.
+// Every flag is opt-in, including Enabled, so upgrading never changes how a
+// repository's approvals behave.
+type ApprovalRetention struct {
+	Enabled               bool  `toml:"enabled"`
+	Whitespace            *bool `toml:"whitespace"`
+	Comments              *bool `toml:"comments"`
+	Formatting            *bool `toml:"formatting"`
+	StringLiterals        *bool `toml:"string_literals"`
+	Renames               *bool `toml:"renames"`
+	FetchOrphanedApproval *bool `toml:"fetch_orphaned_approval"`
+}
+
+func (r *ApprovalRetention) WhitespaceEnabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.enabled(r.Whitespace)
+}
+
+func (r *ApprovalRetention) CommentsEnabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.enabled(r.Comments)
+}
+
+func (r *ApprovalRetention) FormattingEnabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.enabled(r.Formatting)
+}
+
+func (r *ApprovalRetention) StringLiteralsEnabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.enabled(r.StringLiterals)
+}
+
+func (r *ApprovalRetention) RenamesEnabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.enabled(r.Renames)
+}
+
+func (r *ApprovalRetention) FetchOrphanedApprovalEnabled() bool {
+	if r == nil {
+		return false
+	}
+	return r.enabled(r.FetchOrphanedApproval)
+}
+
+// Enabled is a kill switch, not a default: turning it on retains nothing on its own.
+func (r *ApprovalRetention) enabled(flag *bool) bool {
+	return r.Enabled && flag != nil && *flag
 }
 
 func ReadConfig(path string, fileReader codeowners.FileReader) (*Config, error) {
@@ -47,6 +108,7 @@ func ReadConfig(path string, fileReader codeowners.FileReader) (*Config, error) 
 		Enforcement:                 &Enforcement{Approval: false, FailCheck: true},
 		HighPriorityLabels:          []string{},
 		AdminBypass:                 &AdminBypass{Enabled: false, AllowedUsers: []string{}},
+		ApprovalRetention:           &ApprovalRetention{Enabled: false},
 		DetailedReviewers:           false,
 		SelfApprovalViaTeams:        false,
 		DisableSmartDismissal:       false,
@@ -78,6 +140,9 @@ func ReadConfig(path string, fileReader codeowners.FileReader) (*Config, error) 
 	}
 	if config.AdminBypass == nil {
 		config.AdminBypass = defaultConfig.AdminBypass
+	}
+	if config.ApprovalRetention == nil {
+		config.ApprovalRetention = defaultConfig.ApprovalRetention
 	}
 	return config, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -250,6 +250,193 @@ func TestReadConfigFileError(t *testing.T) {
 	}
 }
 
+func TestApprovalRetention(t *testing.T) {
+	type resolved struct {
+		whitespace            bool
+		comments              bool
+		formatting            bool
+		stringLiterals        bool
+		renames               bool
+		fetchOrphanedApproval bool
+	}
+
+	tt := []struct {
+		name          string
+		configContent string
+		expected      resolved
+	}{
+		{
+			name:          "section absent",
+			configContent: "max_reviews = 2",
+			expected:      resolved{},
+		},
+		{
+			name: "umbrella off with nothing else set",
+			configContent: `
+[approval_retention]
+enabled = false
+`,
+			expected: resolved{},
+		},
+		{
+			name: "umbrella off ignores explicitly enabled flags",
+			configContent: `
+[approval_retention]
+enabled = false
+whitespace = true
+string_literals = true
+renames = true
+fetch_orphaned_approval = true
+`,
+			expected: resolved{},
+		},
+		{
+			name: "master switch on retains nothing on its own",
+			configContent: `
+[approval_retention]
+enabled = true
+`,
+			expected: resolved{},
+		},
+		// One flag per case, so an accessor reading the wrong field fails one.
+		{
+			name: "only whitespace asked for",
+			configContent: `
+[approval_retention]
+enabled = true
+whitespace = true
+`,
+			expected: resolved{whitespace: true},
+		},
+		{
+			name: "only comments asked for",
+			configContent: `
+[approval_retention]
+enabled = true
+comments = true
+`,
+			expected: resolved{comments: true},
+		},
+		{
+			name: "only formatting asked for",
+			configContent: `
+[approval_retention]
+enabled = true
+formatting = true
+`,
+			expected: resolved{formatting: true},
+		},
+		{
+			name: "only string_literals asked for",
+			configContent: `
+[approval_retention]
+enabled = true
+string_literals = true
+`,
+			expected: resolved{stringLiterals: true},
+		},
+		{
+			name: "only renames asked for",
+			configContent: `
+[approval_retention]
+enabled = true
+renames = true
+`,
+			expected: resolved{renames: true},
+		},
+		{
+			name: "only fetch_orphaned_approval asked for",
+			configContent: `
+[approval_retention]
+enabled = true
+fetch_orphaned_approval = true
+`,
+			expected: resolved{fetchOrphanedApproval: true},
+		},
+		{
+			name: "a flag asked for without the master switch stays off",
+			configContent: `
+[approval_retention]
+whitespace = true
+comments = true
+formatting = true
+`,
+			expected: resolved{},
+		},
+		{
+			name: "every flag asked for",
+			configContent: `
+[approval_retention]
+enabled = true
+whitespace = true
+comments = true
+formatting = true
+string_literals = true
+renames = true
+fetch_orphaned_approval = true
+`,
+			expected: resolved{
+				whitespace: true, comments: true, formatting: true,
+				stringLiterals: true, renames: true, fetchOrphanedApproval: true,
+			},
+		},
+		{
+			name: "every flag explicitly false",
+			configContent: `
+[approval_retention]
+enabled = true
+whitespace = false
+comments = false
+formatting = false
+string_literals = false
+renames = false
+fetch_orphaned_approval = false
+`,
+			expected: resolved{},
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			testDir := t.TempDir()
+			err := os.WriteFile(filepath.Join(testDir, "codeowners.toml"), []byte(tc.configContent), 0644)
+			if err != nil {
+				t.Fatalf("failed to write test config: %v", err)
+			}
+
+			config, err := ReadConfig(testDir, nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if config.ApprovalRetention == nil {
+				t.Fatal("expected ApprovalRetention to be set")
+			}
+
+			got := resolved{
+				whitespace:            config.ApprovalRetention.WhitespaceEnabled(),
+				comments:              config.ApprovalRetention.CommentsEnabled(),
+				formatting:            config.ApprovalRetention.FormattingEnabled(),
+				stringLiterals:        config.ApprovalRetention.StringLiteralsEnabled(),
+				renames:               config.ApprovalRetention.RenamesEnabled(),
+				fetchOrphanedApproval: config.ApprovalRetention.FetchOrphanedApprovalEnabled(),
+			}
+			if got != tc.expected {
+				t.Errorf("resolved flags: expected %+v, got %+v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func TestApprovalRetentionNilSection(t *testing.T) {
+	var retention *ApprovalRetention
+
+	if retention.WhitespaceEnabled() || retention.CommentsEnabled() || retention.FormattingEnabled() ||
+		retention.StringLiteralsEnabled() || retention.RenamesEnabled() || retention.FetchOrphanedApprovalEnabled() {
+		t.Error("expected all flags to be disabled for a nil section")
+	}
+}
+
 // Helper functions
 func intPtr(i int) *int {
 	return &i

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -129,7 +129,7 @@ Binary files a/assets/img/offline.png and b/assets/img/offline.png differ`,
 			expectedErr:   false,
 			expectedFiles: 2,
 			expectedHunks: map[string]int{
-				"file1.go":                1,
+				"file1.go":               1,
 				"assets/img/offline.png": 0,
 			},
 		},


### PR DESCRIPTION
## Related PR(s)

Base of the approval-retention series. These build on it:

- #184 — partial-parse fix
- #185 — `fetch_orphaned_approval`
- #186 — the shared normalizer, and the three flags on top of it

## Summary / Background

Adds an `[approval_retention]` section to `codeowners.toml`. **No behaviour change** — nothing reads these flags yet. This is the config surface the retention rules land behind.

```toml
[approval_retention]
enabled = false                  # kill switch for the whole section
whitespace = false
comments = false
formatting = false
string_literals = false
renames = false
fetch_orphaned_approval = false
```

### `enabled` is a kill switch, not a default

Every flag is off unless it is named. `enabled` turns nothing on by itself; it switches the whole section off in one line, so a repository can suspend retention without editing seven values.

| `enabled` | flag | result |
| --- | --- | --- |
| `false` | anything | off |
| `true` | unset | off |
| `true` | `true` | on |

One accessor reads that, so no call site can disagree with another:

```go
func (r *ApprovalRetention) enabled(flag *bool) bool {
	return r.Enabled && flag != nil && *flag
}
```

### Why the flags are `*bool`

Behaviour no longer needs it, now that unset and `false` mean the same thing. It is kept so the two can still be told apart: writing `whitespace = false` on purpose reads as a decision, and an absent value reads as one nobody has made yet.

### Opt-in flags

All of them, without exception. `string_literals` and `renames` can alter behaviour without changing the shape of the code an approver reviewed, and `fetch_orphaned_approval` reaches the network, so those three are the ones worth thinking hardest about before switching on.

### Defaults

Everything is off, so nothing changes for anyone until they opt in. An end-to-end test pins that: a config with no section and one spelling the section out with everything off produce the same bytes.

