### PR TITLE
chore: ignore .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ node_modules
 
 # Ignore locally built binary
 codeowners-cli
+
+# Local agent configuration
+.claude/


### PR DESCRIPTION
## Summary / Background

`.claude/` is untracked but not ignored, so a stray `git add -A` would publish whatever local agent configuration happens to be sitting there.

The directory is currently empty, so nothing is exposed today. This is a guard against it becoming a problem later.
