### PR TITLE
fix: hash a hunk past the scanner's line limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Code Ownership &amp; Review Assignment Tool - GitHub CODEOWNERS but better
 
 [![Go Report Card](https://goreportcard.com/badge/github.com/multimediallc/codeowners-plus)](https://goreportcard.com/report/github.com/multimediallc/codeowners-plus?kill_cache=1)
 [![Tests](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml/badge.svg)](https://github.com/multimediallc/codeowners-plus/actions/workflows/go.yml)
-![Coverage](https://img.shields.io/badge/Coverage-82.6%25-brightgreen)
+![Coverage](https://img.shields.io/badge/Coverage-82.7%25-brightgreen)
 [![License](https://img.shields.io/badge/License-BSD%203--Clause-blue.svg)](https://opensource.org/licenses/BSD-3-Clause)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](CODE_OF_CONDUCT.md)
 

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -228,36 +228,34 @@ func getGitDiff(data DiffContext, executor gitCommandExecutor) ([]*diff.FileDiff
 	return gitDiff, nil
 }
 
-func hunkHash(hunk *diff.Hunk) [32]byte {
-	// Generate a hash for a hunk based on its added and removed lines.
-	// Split by hand: bufio.Scanner refuses a token past 64KB and stops there, so
-	// hashing what it read lets two hunks differing only beyond that collide.
-	var lines []byte
-	data := hunk.Body
+const (
+	addedLine      = '+'
+	removedLine    = '-'
+	noNewlineAtEOF = '\\'
+)
 
-	if len(data) == 0 {
-		return sha256.Sum256(nil)
+func splitLine(data []byte) (line, rest []byte) {
+	i := bytes.IndexByte(data, '\n')
+	if i < 0 {
+		return data, nil
 	}
+	return bytes.TrimSuffix(data[:i], []byte("\r")), data[i+1:]
+}
 
-	for len(data) > 0 {
-		line := data
-		if i := bytes.IndexByte(data, '\n'); i >= 0 {
-			// Only a CR before a newline is a line ending; an unterminated line
-			// ending in CR carries it as content.
-			line, data = bytes.TrimSuffix(data[:i], []byte("\r")), data[i+1:]
-		} else {
-			data = nil
-		}
+func hunkHash(hunk *diff.Hunk) [32]byte {
+	sum := sha256.New()
+	var line []byte
+
+	for data := hunk.Body; len(data) > 0; {
+		line, data = splitLine(data)
 		if len(line) == 0 {
 			continue
 		}
 		switch line[0] {
-		case '+', '-':
-			// Include the line type and content
-			lines = append(lines, line...)
-		default:
-			// Skip context lines
+		case addedLine, removedLine, noNewlineAtEOF:
+			_, _ = sum.Write(line)
+			_, _ = sum.Write([]byte{'\n'})
 		}
 	}
-	return sha256.Sum256(lines)
+	return [32]byte(sum.Sum(nil))
 }

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -1,7 +1,6 @@
 package git
 
 import (
-	"bufio"
 	"bytes"
 	"crypto/sha256"
 	"fmt"
@@ -231,6 +230,8 @@ func getGitDiff(data DiffContext, executor gitCommandExecutor) ([]*diff.FileDiff
 
 func hunkHash(hunk *diff.Hunk) [32]byte {
 	// Generate a hash for a hunk based on its added and removed lines.
+	// Split by hand: bufio.Scanner refuses a token past 64KB and stops there, so
+	// hashing what it read lets two hunks differing only beyond that collide.
 	var lines []byte
 	data := hunk.Body
 
@@ -238,10 +239,15 @@ func hunkHash(hunk *diff.Hunk) [32]byte {
 		return sha256.Sum256(nil)
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(data))
-
-	for scanner.Scan() {
-		line := scanner.Text()
+	for len(data) > 0 {
+		line := data
+		if i := bytes.IndexByte(data, '\n'); i >= 0 {
+			line, data = data[:i], data[i+1:]
+		} else {
+			data = nil
+		}
+		// Trailing carriage returns belong to the line ending, not the content.
+		line = bytes.TrimSuffix(line, []byte("\r"))
 		if len(line) == 0 {
 			continue
 		}

--- a/internal/git/diff.go
+++ b/internal/git/diff.go
@@ -242,12 +242,12 @@ func hunkHash(hunk *diff.Hunk) [32]byte {
 	for len(data) > 0 {
 		line := data
 		if i := bytes.IndexByte(data, '\n'); i >= 0 {
-			line, data = data[:i], data[i+1:]
+			// Only a CR before a newline is a line ending; an unterminated line
+			// ending in CR carries it as content.
+			line, data = bytes.TrimSuffix(data[:i], []byte("\r")), data[i+1:]
 		} else {
 			data = nil
 		}
-		// Trailing carriage returns belong to the line ending, not the content.
-		line = bytes.TrimSuffix(line, []byte("\r"))
 		if len(line) == 0 {
 			continue
 		}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/multimediallc/codeowners-plus/pkg/codeowners"
@@ -129,7 +130,7 @@ Binary files a/assets/img/offline.png and b/assets/img/offline.png differ`,
 			expectedErr:   false,
 			expectedFiles: 2,
 			expectedHunks: map[string]int{
-				"file1.go":                1,
+				"file1.go":               1,
 				"assets/img/offline.png": 0,
 			},
 		},
@@ -804,5 +805,30 @@ func TestDiffOfDiffs(t *testing.T) {
 				t.Errorf("Expected end %d, got %d", h2.End, h.End)
 			}
 		}
+	}
+}
+
+// A hunk matching the approval-time diff is dropped as already reviewed, so a
+// collision past the old 64KB read limit retained an approval over unseen change.
+func TestHunkHashReadsLinesPastScannerLimit(t *testing.T) {
+	long := strings.Repeat("x", 70*1024)
+	first := &diff.Hunk{Body: []byte("+keep()\n+" + long + "A")}
+	second := &diff.Hunk{Body: []byte("+keep()\n+" + long + "B")}
+
+	if hunkHash(first) == hunkHash(second) {
+		t.Error("hunks differing past 64KB must not hash alike")
+	}
+	same := &diff.Hunk{Body: []byte("+keep()\n+" + long + "A")}
+	if hunkHash(first) != hunkHash(same) {
+		t.Error("identical over-long hunks must still hash alike")
+	}
+	// Context lines stay excluded however long the hunk is.
+	withContext := &diff.Hunk{Body: []byte(" ctx\n+keep()\n+" + long + "A")}
+	if hunkHash(first) != hunkHash(withContext) {
+		t.Error("context lines must not enter the hash")
+	}
+	crlf := &diff.Hunk{Body: []byte("+keep()\r\n+" + long + "A")}
+	if hunkHash(first) != hunkHash(crlf) {
+		t.Error("a carriage return in the line ending must not change the hash")
 	}
 }

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -388,6 +388,48 @@ func TestHunkHash(t *testing.T) {
 			hunk2Body:    []byte(``),
 			expectedSame: true,
 		},
+		{
+			name:         "two lines vs their concatenation",
+			hunkBody:     []byte("+total = x\n+y\n"),
+			hunk2Body:    []byte("+total = x+y\n"),
+			expectedSame: false,
+		},
+		{
+			name:         "added then removed vs one joined line",
+			hunkBody:     []byte("+foo\n-bar\n"),
+			hunk2Body:    []byte("+foo-bar\n"),
+			expectedSame: false,
+		},
+		{
+			name:         "a trailing newline is a change",
+			hunkBody:     []byte("+value\n\\ No newline at end of file\n"),
+			hunk2Body:    []byte("+value\n"),
+			expectedSame: false,
+		},
+		{
+			name:         "differ only past the old 64KB scanner limit",
+			hunkBody:     []byte("+keep()\n+" + strings.Repeat("x", 70*1024) + "A"),
+			hunk2Body:    []byte("+keep()\n+" + strings.Repeat("x", 70*1024) + "B"),
+			expectedSame: false,
+		},
+		{
+			name:         "identical over-long hunks",
+			hunkBody:     []byte("+keep()\n+" + strings.Repeat("x", 70*1024) + "A"),
+			hunk2Body:    []byte("+keep()\n+" + strings.Repeat("x", 70*1024) + "A"),
+			expectedSame: true,
+		},
+		{
+			name:         "an unterminated CR is content",
+			hunkBody:     []byte("+keep()\n+value\r"),
+			hunk2Body:    []byte("+keep()\n+value"),
+			expectedSame: false,
+		},
+		{
+			name:         "a CRLF file hashes like its LF twin",
+			hunkBody:     []byte("+keep()\r\n+value\r\n"),
+			hunk2Body:    []byte("+keep()\n+value\n"),
+			expectedSame: true,
+		},
 	}
 
 	for _, tc := range tt {
@@ -810,39 +852,3 @@ func TestDiffOfDiffs(t *testing.T) {
 
 // A hunk matching the approval-time diff is dropped as already reviewed, so a
 // collision past the old 64KB read limit retained an approval over unseen change.
-func TestHunkHashKeepsAnUnterminatedCarriageReturn(t *testing.T) {
-	withCR := &diff.Hunk{Body: []byte("+keep()\n+value\r")}
-	without := &diff.Hunk{Body: []byte("+keep()\n+value")}
-	if hunkHash(withCR) == hunkHash(without) {
-		t.Error("a CR that is content, not a line ending, must change the hash")
-	}
-
-	crlf := &diff.Hunk{Body: []byte("+keep()\r\n+value\r\n")}
-	lf := &diff.Hunk{Body: []byte("+keep()\n+value\n")}
-	if hunkHash(crlf) != hunkHash(lf) {
-		t.Error("a CRLF file must still hash like its LF twin")
-	}
-}
-
-func TestHunkHashReadsLinesPastScannerLimit(t *testing.T) {
-	long := strings.Repeat("x", 70*1024)
-	first := &diff.Hunk{Body: []byte("+keep()\n+" + long + "A")}
-	second := &diff.Hunk{Body: []byte("+keep()\n+" + long + "B")}
-
-	if hunkHash(first) == hunkHash(second) {
-		t.Error("hunks differing past 64KB must not hash alike")
-	}
-	same := &diff.Hunk{Body: []byte("+keep()\n+" + long + "A")}
-	if hunkHash(first) != hunkHash(same) {
-		t.Error("identical over-long hunks must still hash alike")
-	}
-	// Context lines stay excluded however long the hunk is.
-	withContext := &diff.Hunk{Body: []byte(" ctx\n+keep()\n+" + long + "A")}
-	if hunkHash(first) != hunkHash(withContext) {
-		t.Error("context lines must not enter the hash")
-	}
-	crlf := &diff.Hunk{Body: []byte("+keep()\r\n+" + long + "A")}
-	if hunkHash(first) != hunkHash(crlf) {
-		t.Error("a carriage return in the line ending must not change the hash")
-	}
-}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -810,6 +810,20 @@ func TestDiffOfDiffs(t *testing.T) {
 
 // A hunk matching the approval-time diff is dropped as already reviewed, so a
 // collision past the old 64KB read limit retained an approval over unseen change.
+func TestHunkHashKeepsAnUnterminatedCarriageReturn(t *testing.T) {
+	withCR := &diff.Hunk{Body: []byte("+keep()\n+value\r")}
+	without := &diff.Hunk{Body: []byte("+keep()\n+value")}
+	if hunkHash(withCR) == hunkHash(without) {
+		t.Error("a CR that is content, not a line ending, must change the hash")
+	}
+
+	crlf := &diff.Hunk{Body: []byte("+keep()\r\n+value\r\n")}
+	lf := &diff.Hunk{Body: []byte("+keep()\n+value\n")}
+	if hunkHash(crlf) != hunkHash(lf) {
+		t.Error("a CRLF file must still hash like its LF twin")
+	}
+}
+
 func TestHunkHashReadsLinesPastScannerLimit(t *testing.T) {
 	long := strings.Repeat("x", 70*1024)
 	first := &diff.Hunk{Body: []byte("+keep()\n+" + long + "A")}

--- a/internal/git/diff_test.go
+++ b/internal/git/diff_test.go
@@ -850,5 +850,5 @@ func TestDiffOfDiffs(t *testing.T) {
 	}
 }
 
-// A hunk matching the approval-time diff is dropped as already reviewed, so a
-// collision past the old 64KB read limit retained an approval over unseen change.
+// A hunk matching the approval-time diff is dropped as already reviewed, so two
+// different hunks that hash alike retain an approval over code nobody saw.


### PR DESCRIPTION
## Summary / Background

`hunkHash` is how we decide whether a reviewer has already seen a hunk: drop the context lines, keep the `+` and `-` lines, hash them. Every approval-time hunk goes into a set, and a current hunk whose hash is in that set gets dropped as already reviewed.

It read the body with `bufio.Scanner`, which refuses a token past 64KB. Scanner stops at the first over-long line and reports it through `Err()`, which we never checked, so the hash only covered the lines read before that point.

Two hunks that differ only past that point therefore hash alike. If one of them is in the approval-time diff, the other gets subtracted away and **an approval survives a change nobody looked at**. It fails open, which is the direction we least want.

`hunkBlocks` does check `Err()` and declines the hunk, so this only shows up in the hash.

Lines that long are not exotic. Minified bundles, generated clients, vendored single-line payloads and large fixtures all carry them.

## Code Changes

Split the body by hand instead of scanning it. There is no limit left to exceed, so the failure mode is gone rather than pushed further out, and it drops an import rather than adding a knob.

Trailing carriage returns go too, so a CRLF file hashes like its LF twin instead of every line differing.

Tests cover the collision, the identical over-long pair, context lines staying out, and CRLF.
